### PR TITLE
Fix docker github action

### DIFF
--- a/.github/workflows/docker-push-vidvec.yml
+++ b/.github/workflows/docker-push-vidvec.yml
@@ -6,18 +6,22 @@ jobs:
   api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: master
+      - name: "Setup Node version"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.9.0
       - name: Declare some variables
         id: vars
         shell: bash
         run: |
           echo "setting variables"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "name=sha_short::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - uses: elgohr/Publish-Docker-Github-Action@master
         with:
           username: tattletech


### PR DESCRIPTION
- Added custom node version action
- Fixed node12 and node16 deprecation warnings by upgrading actions
	- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
	- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- Fixed set-output deprecation warning
	- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
