### PR TITLE
fix: added optional dependencies support to toml script

### DIFF
--- a/operators/cluster_embeddings/pyproject.toml
+++ b/operators/cluster_embeddings/pyproject.toml
@@ -2,21 +2,14 @@
 name = "feluda-cluster-embeddings"
 version = "0.1.2"
 requires-python = ">=3.10"
-dependencies = [
-    "scikit-learn>=1.6.0",
-    "numpy>=2.2.1",
-]
+dependencies = ["scikit-learn>=1.6.0", "numpy>=2.2.1"]
 
 [build-system]
-requires = [
-    "hatchling",
-]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.semantic_release]
-version_variable = [
-    "pyproject.toml:project.version",
-]
+version_variable = ["pyproject.toml:project.version"]
 
 [tool.semantic_release.branches.main]
 match = "main"
@@ -24,6 +17,4 @@ prerelease = false
 tag_format = "{name}-{version}"
 
 [tool.hatch.build.targets.wheel]
-packages = [
-    ".",
-]
+packages = ["."]

--- a/operators/dimension_reduction/pyproject.toml
+++ b/operators/dimension_reduction/pyproject.toml
@@ -2,21 +2,14 @@
 name = "feluda-dimension-reduction"
 version = "0.1.2"
 requires-python = ">=3.10"
-dependencies = [
-    "scikit-learn>=1.6.0",
-    "numpy>=2.2.1",
-]
+dependencies = ["scikit-learn>=1.6.0", "numpy>=2.2.1"]
 
 [build-system]
-requires = [
-    "hatchling",
-]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.semantic_release]
-version_variable = [
-    "pyproject.toml:project.version",
-]
+version_variable = ["pyproject.toml:project.version"]
 
 [tool.semantic_release.branches.main]
 match = "main"
@@ -24,6 +17,4 @@ prerelease = false
 tag_format = "{name}-{version}"
 
 [tool.hatch.build.targets.wheel]
-packages = [
-    ".",
-]
+packages = ["."]

--- a/operators/image_vec_rep_resnet/pyproject.toml
+++ b/operators/image_vec_rep_resnet/pyproject.toml
@@ -10,15 +10,11 @@ dependencies = [
 ]
 
 [build-system]
-requires = [
-    "hatchling",
-]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.semantic_release]
-version_variable = [
-    "pyproject.toml:project.version",
-]
+version_variable = ["pyproject.toml:project.version"]
 
 [tool.semantic_release.branches.main]
 match = "main"
@@ -26,6 +22,4 @@ prerelease = false
 tag_format = "{name}-{version}"
 
 [tool.hatch.build.targets.wheel]
-packages = [
-    ".",
-]
+packages = ["."]

--- a/operators/vid_vec_rep_clip/pyproject.toml
+++ b/operators/vid_vec_rep_clip/pyproject.toml
@@ -10,15 +10,11 @@ dependencies = [
 ]
 
 [build-system]
-requires = [
-    "hatchling",
-]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.semantic_release]
-version_variable = [
-    "pyproject.toml:project.version",
-]
+version_variable = ["pyproject.toml:project.version"]
 
 [tool.semantic_release.branches.main]
 match = "main"
@@ -26,6 +22,4 @@ prerelease = false
 tag_format = "{name}-{version}"
 
 [tool.hatch.build.targets.wheel]
-packages = [
-    ".",
-]
+packages = ["."]

--- a/scripts/toml_dependencies_update_script.py
+++ b/scripts/toml_dependencies_update_script.py
@@ -1,10 +1,10 @@
 import os
 import re
-
-import toml
+import tomlkit
 
 
 def find_pyproject_files():
+    """Find all pyproject.toml files in the project."""
     current_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     pyproject_files = []
 
@@ -19,44 +19,63 @@ def find_pyproject_files():
 
 
 def load_lock_file(lock_file_path):
-    with open(lock_file_path, "r") as lock_file:
-        lock_data = toml.load(lock_file)
+    """Load the lock file in custom format."""
+    lock_data = {"package": []}
+
+    with open(lock_file_path, "r", encoding="utf-8") as lock_file:
+        for line in lock_file:
+            match = re.match(r"^([a-zA-Z0-9\-_]+)==([\d\.]+)", line.strip())
+            if match:
+                package_name = match.group(1)
+                package_version = match.group(2)
+                lock_data["package"].append({"name": package_name, "version": package_version})
+
     return lock_data
 
 
-def update_pyproject_versions(toml_file_path, lock_data):
-    with open(toml_file_path, "r") as file:
-        toml_data = toml.load(file)
-
-    for idx, dependency in enumerate(toml_data["project"]["dependencies"]):
+def update_dependencies(dependencies, lock_data):
+    """Update dependencies based on the lock file."""
+    for idx, dependency in enumerate(dependencies):
         dep_match = re.match(r"([a-zA-Z0-9\-_]+)([><=~!]*[\d\.]+)?", dependency)
 
         if dep_match:
-            dep_name = dep_match.group(1)  # Get the package name
-            dep_version_spec = dep_match.group(2)  # Get the version specifier (if any)
+            dep_name = dep_match.group(1)  
+            dep_version_spec = dep_match.group(2)  
 
             for pkg in lock_data["package"]:
-                # If the lock file package name matches, update the version
                 if pkg["name"] == dep_name:
                     new_version = pkg["version"]
                     if dep_version_spec:
-                        toml_data["project"]["dependencies"][idx] = (
+                        dependencies[idx] = (
                             f"{dep_name}{dep_version_spec.replace(dep_version_spec, f'>={new_version}')}"
                         )
                     else:
-                        toml_data["project"]["dependencies"][idx] = (
-                            f"{dep_name}>={new_version}"
-                        )
+                        dependencies[idx] = f"{dep_name}>={new_version}"
 
-    with open(toml_file_path, "w") as file:
-        toml.dump(toml_data, file)
+
+def update_pyproject_versions(toml_file_path, lock_data):
+    """Update the dependencies in a pyproject.toml file."""
+    with open(toml_file_path, "r", encoding="utf-8") as file:
+        toml_data = tomlkit.parse(file.read())
+
+    # Update [project.dependencies]
+    if "dependencies" in toml_data["project"]:
+        update_dependencies(toml_data["project"]["dependencies"], lock_data)
+
+    # Update [project.optional-dependencies]
+    if "optional-dependencies" in toml_data["project"]:
+        for group, dependencies in toml_data["project"]["optional-dependencies"].items():
+            update_dependencies(dependencies, lock_data)
+
+    with open(toml_file_path, "w", encoding="utf-8") as file:
+        file.write(tomlkit.dumps(toml_data))
 
 
 if __name__ == "__main__":
     toml_file_paths = find_pyproject_files()
+
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     lock_file_path = os.path.join(project_root, "uv.lock")
-
     lock_data = load_lock_file(lock_file_path)
 
     print("Updating TOML file packages...")

--- a/scripts/toml_dependencies_update_script.py
+++ b/scripts/toml_dependencies_update_script.py
@@ -1,92 +1,188 @@
-import os
 import re
+from pathlib import Path
 
 import tomlkit
 
 
-def find_pyproject_files():
+def find_pyproject_files(start_dir=None):
     """Find all pyproject.toml files in the project."""
-    current_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if start_dir is None:
+        start_dir = Path(__file__).parent.parent.absolute()
+    else:
+        start_dir = Path(start_dir).absolute()
+
+    ignore_dirs = {"dist", ".venv", ".ruff_cache", "__pycache__", ".git"}
     pyproject_files = []
 
-    for root, dirs, files in os.walk(current_dir):
-        # Ignore a set of folders
-        dirs[:] = [
-            d for d in dirs if d not in {"dist", ".venv", ".ruff_cache", ".docker"}
-        ]
-
-        if "pyproject.toml" in files:
-            pyproject_files.append(os.path.join(root, "pyproject.toml"))
+    for path in start_dir.rglob("pyproject.toml"):
+        # Check if any part of the path is in the ignore list
+        if not any(ignored in path.parts for ignored in ignore_dirs):
+            pyproject_files.append(path)
 
     return pyproject_files
 
 
 def load_lock_file(lock_file_path):
-    """Load the lock file in custom format."""
-    lock_data = {"package": []}
+    """
+    Load the UV lock file in TOML format.
+    Returns a dictionary mapping package names to their versions.
+    """
+    lock_data = {}
 
     with open(lock_file_path, "r", encoding="utf-8") as lock_file:
-        for line in lock_file:
-            match = re.match(r"^([a-zA-Z0-9\-_]+)==([\d\.]+)", line.strip())
-            if match:
-                package_name = match.group(1)
-                package_version = match.group(2)
-                lock_data["package"].append(
-                    {"name": package_name, "version": package_version}
-                )
+        content = lock_file.read()
+
+    try:
+        parsed = tomlkit.parse(content)
+        for package in parsed.get("package", []):
+            if isinstance(package, dict) and "name" in package and "version" in package:
+                lock_data[package["name"]] = package["version"]
+
+    except Exception as e:
+        print(f"Error parsing lock file: {e}")
+        # Try alternative parsing if tomlkit fails
+        package_blocks = re.findall(
+            r"\[\[package\]\](.*?)(?=\[\[package\]\]|\Z)", content, re.DOTALL
+        )
+        for block in package_blocks:
+            name_match = re.search(r'name\s*=\s*"([^"]+)"', block)
+            version_match = re.search(r'version\s*=\s*"([^"]+)"', block)
+            if name_match and version_match:
+                lock_data[name_match.group(1)] = version_match.group(1)
 
     return lock_data
 
 
-def update_dependencies(dependencies, lock_data):
-    """Update dependencies based on the lock file."""
+def update_dependency_version(dependency_str, package_versions):
+    """
+    Update a single dependency string based on available package versions.
+    Returns the updated dependency string or the original if no update is needed.
+    """
+    dep_match = re.match(r"([a-zA-Z0-9\-_\.]+)([><=~!]+.*)?", dependency_str.strip())
+
+    if not dep_match:
+        return dependency_str
+
+    package_name = dep_match.group(1)
+    version_constraint = dep_match.group(2) or ""
+
+    if package_name in package_versions:
+        new_version = package_versions[package_name]
+
+        # Keep any existing comparison operators (>=, ==, etc.)
+        constraint_type = re.match(r"([><=~!]+)", version_constraint)
+        if constraint_type:
+            # Replace only the version part, keeping the operator
+            new_dependency = f"{package_name}{constraint_type.group(1)}{new_version}"
+        else:
+            # No operator, add >= with the new version
+            new_dependency = f"{package_name}>={new_version}"
+
+        return new_dependency
+
+    return dependency_str
+
+
+def update_dependencies_list(dependencies, package_versions):
+    """
+    Update a list of dependencies based on the lock file data.
+    Modifies the list in-place and returns a count of updated packages.
+    """
+    updated_count = 0
+
     for idx, dependency in enumerate(dependencies):
-        dep_match = re.match(r"([a-zA-Z0-9\-_]+)([><=~!]*[\d\.]+)?", dependency)
+        original = dependency
+        dependencies[idx] = update_dependency_version(dependency, package_versions)
+        if dependencies[idx] != original:
+            updated_count += 1
 
-        if dep_match:
-            dep_name = dep_match.group(1)
-            dep_version_spec = dep_match.group(2)
-
-            for pkg in lock_data["package"]:
-                if pkg["name"] == dep_name:
-                    new_version = pkg["version"]
-                    if dep_version_spec:
-                        dependencies[idx] = (
-                            f"{dep_name}{dep_version_spec.replace(dep_version_spec, f'>={new_version}')}"
-                        )
-                    else:
-                        dependencies[idx] = f"{dep_name}>={new_version}"
+    return updated_count
 
 
-def update_pyproject_versions(toml_file_path, lock_data):
-    """Update the dependencies in a pyproject.toml file."""
-    with open(toml_file_path, "r", encoding="utf-8") as file:
-        toml_data = tomlkit.parse(file.read())
+def update_pyproject_versions(toml_file_path, package_versions):
+    """
+    Update the dependencies in a pyproject.toml file.
+    Returns the number of updated dependencies.
+    """
+    try:
+        with open(toml_file_path, "r", encoding="utf-8") as file:
+            toml_data = tomlkit.parse(file.read())
 
-    # Update [project.dependencies]
-    if "dependencies" in toml_data["project"]:
-        update_dependencies(toml_data["project"]["dependencies"], lock_data)
+        total_updated = 0
 
-    # Update [project.optional-dependencies]
-    if "optional-dependencies" in toml_data["project"]:
-        for group, dependencies in toml_data["project"][
-            "optional-dependencies"
-        ].items():
-            update_dependencies(dependencies, lock_data)
+        # Update [project.dependencies]
+        if "project" in toml_data and "dependencies" in toml_data["project"]:
+            updated = update_dependencies_list(
+                toml_data["project"]["dependencies"], package_versions
+            )
+            total_updated += updated
 
-    with open(toml_file_path, "w", encoding="utf-8") as file:
-        file.write(tomlkit.dumps(toml_data))
+        # Update [project.optional-dependencies]
+        if "project" in toml_data and "optional-dependencies" in toml_data["project"]:
+            for group, dependencies in toml_data["project"][
+                "optional-dependencies"
+            ].items():
+                updated = update_dependencies_list(dependencies, package_versions)
+                total_updated += updated
+
+        if total_updated > 0:
+            with open(toml_file_path, "w", encoding="utf-8") as file:
+                file.write(tomlkit.dumps(toml_data))
+
+            print(f"Updated {total_updated} dependencies in {toml_file_path}")
+            return total_updated
+        else:
+            print(f"No dependencies to update in {toml_file_path}")
+            return 0
+
+    except Exception as e:
+        print(f"Error updating {toml_file_path}: {e}")
+        return 0
+
+
+def main():
+    """Main function to find and update pyproject.toml files."""
+    try:
+        project_root = Path(__file__).parent.parent.absolute()
+        lock_file_path = project_root / "uv.lock"
+
+        if not lock_file_path.exists():
+            print(f"Error: Lock file not found at {lock_file_path}")
+            return
+
+        # Find all pyproject.toml files
+        toml_file_paths = find_pyproject_files(project_root)
+        if not toml_file_paths:
+            print("No pyproject.toml files found")
+            return
+        print(f"Found {len(toml_file_paths)} pyproject.toml files")
+
+        # Load lock file data
+        print(f"Loading lock file from {lock_file_path}")
+        package_versions = load_lock_file(lock_file_path)
+        if not package_versions:
+            print("No package information found in lock file")
+            return
+        print(f"Found {len(package_versions)} packages in lock file")
+
+        # Update each pyproject.toml file
+        total_updated_files = 0
+        total_updated_deps = 0
+
+        for toml_file_path in toml_file_paths:
+            print(f"Processing {toml_file_path}")
+            updated = update_pyproject_versions(toml_file_path, package_versions)
+            if updated > 0:
+                total_updated_files += 1
+                total_updated_deps += updated
+
+        print(
+            f"\nSummary: Updated {total_updated_deps} dependencies in {total_updated_files} files"
+        )
+
+    except Exception as e:
+        print(f"An error occurred during execution: {e}")
 
 
 if __name__ == "__main__":
-    toml_file_paths = find_pyproject_files()
-
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    lock_file_path = os.path.join(project_root, "uv.lock")
-    lock_data = load_lock_file(lock_file_path)
-
-    print("Updating TOML file packages...")
-    for toml_file_path in toml_file_paths:
-        update_pyproject_versions(toml_file_path, lock_data)
-
-    print("Updating Done")
+    main()

--- a/tests/scripts/test_toml_dependencies_update_script.py
+++ b/tests/scripts/test_toml_dependencies_update_script.py
@@ -1,0 +1,245 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+# Import the script functions to test
+from scripts.toml_dependencies_update_script import (
+    find_pyproject_files,
+    load_lock_file,
+    update_dependencies_list,
+    update_dependency_version,
+    update_pyproject_versions,
+)
+
+
+class TestPyprojectFileFinder(unittest.TestCase):
+    """Test the find_pyproject_files function."""
+
+    def setUp(self):
+        # Create temporary directory structure for testing
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.test_dir = Path(self.temp_dir.name)
+
+        # Create some test pyproject.toml files
+        (self.test_dir / "pyproject.toml").touch()
+        (self.test_dir / "project1").mkdir()
+        (self.test_dir / "project1" / "pyproject.toml").touch()
+        (self.test_dir / "project2").mkdir()
+        (self.test_dir / "project2" / "pyproject.toml").touch()
+
+        # Create ignored directories with pyproject files
+        (self.test_dir / ".venv").mkdir()
+        (self.test_dir / ".venv" / "pyproject.toml").touch()
+        (self.test_dir / "dist").mkdir()
+        (self.test_dir / "dist" / "pyproject.toml").touch()
+        (self.test_dir / "__pycache__").mkdir()
+        (self.test_dir / "__pycache__" / "pyproject.toml").touch()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_find_pyproject_files(self):
+        """Test that pyproject.toml files are found correctly."""
+        files = find_pyproject_files(self.test_dir)
+
+        # Should find 3 files (root, project1, project2)
+        self.assertEqual(len(files), 3)
+
+        # Check that the files are the ones we expect
+        file_paths = [str(f) for f in files]
+        self.assertTrue(str(self.test_dir / "pyproject.toml") in file_paths)
+        self.assertTrue(
+            str(self.test_dir / "project1" / "pyproject.toml") in file_paths
+        )
+        self.assertTrue(
+            str(self.test_dir / "project2" / "pyproject.toml") in file_paths
+        )
+
+        # Check that ignored directories are not included
+        self.assertFalse(str(self.test_dir / ".venv" / "pyproject.toml") in file_paths)
+        self.assertFalse(str(self.test_dir / "dist" / "pyproject.toml") in file_paths)
+        self.assertFalse(
+            str(self.test_dir / "__pycache__" / "pyproject.toml") in file_paths
+        )
+
+
+class TestLockFileParser(unittest.TestCase):
+    """Test the load_lock_file function."""
+
+    def test_parse_valid_toml(self):
+        """Test parsing a valid TOML lock file."""
+        mock_lock_content = """
+        [[package]]
+        name = "requests"
+        version = "2.28.1"
+
+        [[package]]
+        name = "pytest"
+        version = "7.1.3"
+        """
+
+        with patch("builtins.open", mock_open(read_data=mock_lock_content)):
+            result = load_lock_file("fake_path.lock")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["requests"], "2.28.1")
+        self.assertEqual(result["pytest"], "7.1.3")
+
+    def test_parse_malformed_toml_fallback(self):
+        """Test fallback regex parsing for malformed TOML."""
+        # This is intentionally malformed TOML but with valid package info for regex to find
+        mock_lock_content = """
+        [[package]]
+        name = "requests"
+        version = "2.28.1"
+        broken syntax here
+
+        [[package]]
+        name = "pytest"
+        version = "7.1.3"
+        """
+
+        # Mock tomlkit.parse to raise an exception to trigger fallback
+        with patch("tomlkit.parse", side_effect=Exception("TOML parse error")):
+            with patch("builtins.open", mock_open(read_data=mock_lock_content)):
+                result = load_lock_file("fake_path.lock")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["requests"], "2.28.1")
+        self.assertEqual(result["pytest"], "7.1.3")
+
+    def test_empty_lock_file(self):
+        """Test handling an empty lock file."""
+        with patch("builtins.open", mock_open(read_data="")):
+            result = load_lock_file("fake_path.lock")
+
+        self.assertEqual(len(result), 0)
+
+
+class TestDependencyUpdates(unittest.TestCase):
+    """Test the dependency update functions."""
+
+    def setUp(self):
+        self.package_versions = {
+            "requests": "2.28.1",
+            "pytest": "7.1.3",
+            "numpy": "1.23.3",
+            "pandas": "1.5.0",
+        }
+
+    def test_update_dependency_no_constraint(self):
+        """Test updating a dependency with no version constraint."""
+        result = update_dependency_version("requests", self.package_versions)
+        self.assertEqual(result, "requests>=2.28.1")
+
+    def test_update_dependency_with_constraint(self):
+        """Test updating a dependency with an existing constraint."""
+        result = update_dependency_version("requests>=2.26.0", self.package_versions)
+        self.assertEqual(result, "requests>=2.28.1")
+
+    def test_update_dependency_equals_constraint(self):
+        """Test updating a dependency with an equals constraint."""
+        result = update_dependency_version("requests==2.26.0", self.package_versions)
+        self.assertEqual(result, "requests==2.28.1")
+
+    def test_update_nonexistent_package(self):
+        """Test handling a package not in the versions dictionary."""
+        result = update_dependency_version("nonexistent>=1.0.0", self.package_versions)
+        self.assertEqual(result, "nonexistent>=1.0.0")
+
+    def test_update_dependencies_list(self):
+        """Test updating a list of dependencies."""
+        dependencies = [
+            "requests>=2.26.0",
+            "pytest==7.0.0",
+            "nonexistent>=1.0.0",
+            "numpy",
+        ]
+
+        updated = update_dependencies_list(dependencies, self.package_versions)
+
+        self.assertEqual(updated, 3)  # 3 packages should be updated
+        self.assertEqual(dependencies[0], "requests>=2.28.1")
+        self.assertEqual(dependencies[1], "pytest==7.1.3")
+        self.assertEqual(dependencies[2], "nonexistent>=1.0.0")  # Unchanged
+        self.assertEqual(dependencies[3], "numpy>=1.23.3")
+
+
+class TestPyprojectUpdates(unittest.TestCase):
+    """Test updating full pyproject.toml files."""
+
+    def setUp(self):
+        self.package_versions = {
+            "requests": "2.28.1",
+            "pytest": "7.1.3",
+            "numpy": "1.23.3",
+            "pandas": "1.5.0",
+        }
+
+        self.pyproject_content = """
+        [project]
+        name = "test-project"
+        version = "0.1.0"
+        dependencies = [
+            "requests>=2.26.0",
+            "numpy"
+        ]
+
+        [project.optional-dependencies]
+        test = [
+            "pytest==7.0.0"
+        ]
+        dev = [
+            "pandas>=1.4.0",
+            "nonexistent>=1.0.0"
+        ]
+        """
+
+    @patch("builtins.open")
+    def test_update_pyproject_versions(self, mock_open_func):
+        """Test updating versions in a pyproject.toml file."""
+        # Setup mock for file reading
+        mock_file = mock_open_func.return_value.__enter__.return_value
+        mock_file.read.return_value = self.pyproject_content
+
+        # Execute function
+        result = update_pyproject_versions("fake_path.toml", self.package_versions)
+
+        # Check results
+        self.assertEqual(result, 4)
+
+        # Check the file was written with updated content
+        mock_open_func.assert_called_with("fake_path.toml", "w", encoding="utf-8")
+
+        # Get the written content
+        written_calls = mock_file.write.call_args_list
+        self.assertEqual(len(written_calls), 1)
+
+        # Convert to string for easier assertions
+        written_content = written_calls[0][0][0]
+
+        # Check that dependencies were updated correctly
+        self.assertIn('"requests>=2.28.1"', written_content)
+        self.assertIn('"numpy>=1.23.3"', written_content)
+        self.assertIn('"pytest==7.1.3"', written_content)
+        self.assertIn('"pandas>=1.5.0"', written_content)
+        self.assertIn('"nonexistent>=1.0.0"', written_content)  # Unchanged
+
+    @patch("builtins.open")
+    def test_no_dependencies_to_update(self, mock_open_func):
+        """Test handling a file with no dependencies to update."""
+        # Setup mock for reading a file with no updateable dependencies
+        no_deps_content = """
+        [project]
+        name = "test-project"
+        version = "0.1.0"
+        """
+        mock_file = mock_open_func.return_value.__enter__.return_value
+        mock_file.read.return_value = no_deps_content
+
+        # Execute function
+        result = update_pyproject_versions("fake_path.toml", self.package_versions)
+
+        # Check results
+        self.assertEqual(result, 0)


### PR DESCRIPTION
I have made the following changes regarding [issue ](https://github.com/tattle-made/feluda/issues/522#issue-2962259481).
### Key Changes in `toml_dependencies_update_script.py`

1. **Custom Parsing for `uv.lock` File**:
   - Added a custom parser in `load_lock_file` to handle the `uv.lock` file format (`package==version`).
   - Extracts package names and versions into a structured dictionary.

2. **Support for `[project.optional-dependencies]`**:
   - Extended the script to update dependencies listed under `[project.optional-dependencies]`.
   - Iterates through each group in `[project.optional-dependencies]` and updates the dependencies.

3. **Dependency Update Logic**:
   - Added `update_dependencies` function to handle dependency updates for both `[project.dependencies]` and `[project.optional-dependencies]`.
