### PR TITLE
#473 GitHub action to publish python packages to PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -66,28 +66,51 @@ jobs:
           
           for package in "${PACKAGES[@]}"; do
             echo "Processing package: $package"
-            cd "$package" || exit 1
             
-            # Build the package first
-            echo "Building package: $package"
-            uv build --index-strategy unsafe-best-match
-            ls -la dist/
-            
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "DRY RUN: Would publish $package to $PUBLISH_URL"
-              # Just list the files that would be published without actually uploading
-              echo "Files that would be published:"
-              ls -la dist/
-            else
-              echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
-              if [ -n "$PUBLISH_URL" ]; then
-                uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+            # Special handling for the main feluda package which has pyproject.toml in the root
+            if [ "$package" = "feluda" ]; then
+              echo "Building root feluda package from repository root"
+              # Build from the root directory
+              uv build --index-strategy unsafe-best-match
+              
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "DRY RUN: Would publish feluda to $PUBLISH_URL"
+                # Just list the files that would be published without actually uploading
+                echo "Files that would be published:"
+                ls -la dist/
               else
-                uv publish --token "$PYPI_TOKEN"
+                echo "LIVE RUN: Publishing feluda to $PUBLISH_URL"
+                if [ -n "$PUBLISH_URL" ]; then
+                  uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+                else
+                  uv publish --token "$PYPI_TOKEN"
+                fi
               fi
+            else
+              # Normal handling for operator packages that have their own pyproject.toml
+              cd "$package" || exit 1
+              
+              # Build the package
+              echo "Building package: $package"
+              uv build --index-strategy unsafe-best-match
+              ls -la dist/
+              
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "DRY RUN: Would publish $package to $PUBLISH_URL"
+                # Just list the files that would be published without actually uploading
+                echo "Files that would be published:"
+                ls -la dist/
+              else
+                echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
+                if [ -n "$PUBLISH_URL" ]; then
+                  uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+                else
+                  uv publish --token "$PYPI_TOKEN"
+                fi
+              fi
+              
+              cd - > /dev/null
             fi
-            
-            cd - > /dev/null
           done
 
       - name: Summary

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,204 +2,110 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Perform a dry run (no actual publishing)'
-        required: false
-        default: true
-        type: boolean
-      publish_url:
-        description: 'PyPI publish URL (use https://test.pypi.org/legacy/ for TestPyPI)'
-        required: false
-        default: 'https://test.pypi.org/legacy/'
-        type: string
-      verify_tags:
-        description: 'Verify package versions match git tags'
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # Required for trusted publishing to PyPI
+      contents: write
+      id-token: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Needed for tag verification
+          fetch-depth: 0
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
-      - name: Install dependencies
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install required packages
         run: |
-          python -m pip install --upgrade pip
-          pip install uv tomlkit requests
+          uv venv
+          source .venv/bin/activate
+          uv pip install requests tomlkit
 
-      - name: Find packages with updated versions
-        id: find-packages
+      - name: Discover updated packages
+        id: discover
+        run: |
+          uv run -m scripts.find_updated_packages
         env:
-          # Pass publish URL to script to check against TestPyPI if needed
-          CHECK_TEST_PYPI: ${{ inputs.publish_url == 'https://test.pypi.org/legacy/' }}
-          VERIFY_TAGS: ${{ inputs.verify_tags }}
+          CHECK_TEST_PYPI: false
+          VERIFY_TAGS: true
+
+      - name: Fail if tag verification issues exist
+        if: always()
         run: |
-          python -m scripts.find_updated_packages
-          if [ -f packages_to_publish.txt ]; then
-            # Store comma-separated list and count as outputs
-            echo "packages_to_publish=$(cat packages_to_publish.txt)" >> $GITHUB_OUTPUT
-            echo "packages_count=$(wc -w < packages_to_publish.txt | tr -d ' ')" >> $GITHUB_OUTPUT # Count words (packages)
-          else
-            echo "packages_to_publish=" >> $GITHUB_OUTPUT
-            echo "packages_count=0" >> $GITHUB_OUTPUT
-          fi
-          
-          # Check if tag verification found issues
           if [ -f tag_verification_issues.txt ]; then
-            echo "has_tag_issues=true" >> $GITHUB_OUTPUT
+            echo "❌ Tag verification issues found:"
+            cat tag_verification_issues.txt
+            echo "⛔️ Aborting publish step due to tag issues."
+            exit 1
           else
-            echo "has_tag_issues=false" >> $GITHUB_OUTPUT
+            echo "✅ No tag verification issues."
           fi
 
-      - name: Build packages
-        # Run only if there are packages to publish
-        if: steps.find-packages.outputs.packages_to_publish != ''
-        id: build-packages
-        env:
-          # Target repository URL (TestPyPI or Production)
-          PUBLISH_URL: ${{ inputs.publish_url }}
+      - name: Print pyproject.toml paths of packages to publish
+        id: list_paths
         run: |
-          set -e # Exit on any error
-
-          # Read the list of packages to publish
-          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-          
-          # Clean slate for build artifacts
-          rm -rf dist dist_backup
-          mkdir -p dist
-          
-          # Display warnings from previous steps
-          if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
-            echo "::warning::Some packages have tag verification issues. See 'Find packages' step logs."
-            cat tag_verification_issues.txt || true # Display if exists
-          fi
-          
-          # Create artifacts directory for saving build info
-          mkdir -p artifacts
-          cp packages_to_publish.txt artifacts/ || echo "packages_to_publish.txt not found"
-          [ -f tag_verification_issues.txt ] && cp tag_verification_issues.txt artifacts/ || echo "No tag verification issues found"
-          
-          # Build packages sequentially
-          echo "Building packages..."
-          for package_path in "${PACKAGES[@]}"; do
-            echo "--- Processing package: $package_path ---"
-            
-            if [ "$package_path" = "." ] || [ "$package_path" = "feluda" ]; then
-              echo "Building root package (.)"
-              uv build --index-strategy unsafe-best-match
-            else
-              echo "Building package: $package_path"
-              ( # Subshell for cd
-                cd "$package_path" || exit 1
-                uv build --index-strategy unsafe-best-match # Builds in root dist
-              )
-            fi
-            
-            # Check for build success by checking if files were created
-            if [ ! "$(ls -A dist 2>/dev/null)" ]; then
-              echo "::error::No artifacts were created for $package_path"
-              exit 1
-            fi
-            
-            # Keep a copy of built artifacts in the artifacts directory
-            mkdir -p "artifacts/dist/$package_path"
-            cp dist/* "artifacts/dist/$package_path/" || true
-            
-            echo "Build successful for $package_path"
-          done
-          
-          echo "Contents of dist/ directory:"
-          ls -lR dist/
-          
-          echo "has_built_packages=true" >> $GITHUB_OUTPUT
-
-      - name: Publish to PyPI
-        # Run only if packages were built and not in dry-run mode
-        if: steps.build-packages.outputs.has_built_packages == 'true' && inputs.dry_run == false
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          PUBLISH_URL: ${{ inputs.publish_url }}
-        run: |
-          set -e # Exit on any error
-          
-          # Check if dist directory is not empty
-          if [ ! "$(ls -A dist)" ]; then
-            echo "::error::Dist directory is empty. No packages to publish."
+          if [ ! -f packages_to_publish.txt ]; then
+            echo "No packages_to_publish.txt file found."
             exit 1
           fi
-          
-          echo "Publishing packages to ${PUBLISH_URL:-PyPI Production}..."
-          
-          # Use uv publish with the target URL and token
-          if [ -n "$PUBLISH_URL" ]; then
-            # Publish to specified URL (e.g., TestPyPI)
-            uv publish dist/* --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-          else
-            # Publish to production PyPI
-            uv publish dist/* --token "$PYPI_TOKEN"
-          fi
-          
-          echo "Publish command completed successfully."
 
-      - name: Upload Artifacts
-        # Run only if packages were processed
-        if: steps.find-packages.outputs.packages_to_publish != ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: artifacts/
-          retention-days: 3
-          if-no-files-found: warn
+          echo "📝 Packages to publish:"
+          cat packages_to_publish.txt
 
-      - name: Summary
-        # Always run to provide a summary
-        run: |
-          echo "## Publish to PyPI Summary" >> $GITHUB_STEP_SUMMARY
-          
-          if [ -z "${{ steps.find-packages.outputs.packages_to_publish }}" ]; then
-            echo "No packages required publishing based on version checks." >> $GITHUB_STEP_SUMMARY
-          else
-            PUBLISH_DESTINATION="${{ inputs.publish_url }}"
-            if [ -z "$PUBLISH_DESTINATION" ]; then PUBLISH_DESTINATION="PyPI Production"; fi
-
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
-              echo "### 🧪 DRY RUN MODE" >> $GITHUB_STEP_SUMMARY
-              echo "The following **${{ steps.find-packages.outputs.packages_count }}** package(s) were processed for **$PUBLISH_DESTINATION** (no actual publishing):" >> $GITHUB_STEP_SUMMARY
+          echo ""
+          echo "🔍 Finding pyproject.toml paths:"
+          IFS=',' read -ra PACKAGES <<< "$(cat packages_to_publish.txt)"
+          for pkg in "${PACKAGES[@]}"; do
+            if [ "$pkg" == "feluda" ]; then
+              echo " - $pkg/pyproject.toml => ./pyproject.toml"
             else
-              echo "### 🚀 LIVE PUBLISHING MODE" >> $GITHUB_STEP_SUMMARY
-              echo "Attempted to publish the following **${{ steps.find-packages.outputs.packages_count }}** package(s) to **$PUBLISH_DESTINATION**:" >> $GITHUB_STEP_SUMMARY
+              echo " - $pkg/pyproject.toml => $pkg/pyproject.toml"
             fi
-            
-            # List packages
-            IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-            for package_path in "${PACKAGES[@]}"; do
-              # Get package name/version again for display
-              if [ "$package_path" = "." ] || [ "$package_path" = "feluda" ]; then PYPROJECT_PATH="pyproject.toml"; else PYPROJECT_PATH="$package_path/pyproject.toml"; fi
-              PACKAGE_INFO=$(python -c "import sys, tomlkit; data=tomlkit.parse(open('$PYPROJECT_PATH').read()); print(data['project']['name'] + ',' + data['project']['version'])")
-              PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
-              PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
-              
-              echo "- **$PACKAGE_NAME** v$PACKAGE_VERSION (from \`$package_path\`)" >> $GITHUB_STEP_SUMMARY
-            done
-            
-            # Add warnings
-            if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
-              echo "### ⚠️ Warnings" >> $GITHUB_STEP_SUMMARY
-              echo "- Git tag verification issues detected. See logs and artifacts." >> $GITHUB_STEP_SUMMARY
-            fi
+          done
+
+      - name: Build and publish updated packages
+        run: |
+          if [ ! -f packages_to_publish.txt ]; then
+            echo "❌ No packages_to_publish.txt file found."
+            exit 1
           fi
+
+          IFS=',' read -ra PACKAGES <<< "$(cat packages_to_publish.txt)"
+          for pkg in "${PACKAGES[@]}"; do
+            echo "📦 Processing package: $pkg"
+
+            if [ "$pkg" == "feluda" ]; then
+              echo "➡️ Root package: $pkg"
+              uv pip install .
+              uv build
+              uv publish --token $PYPI_PUBLISH_TOKEN
+              rm -rf dist/
+            else
+              echo "➡️ Operator package: $pkg"
+              uv pip install -r $pkg
+              uv build $pkg
+              uv publish --token $PYPI_PUBLISH_TOKEN
+              rm -rf dist/
+            fi
+
+            echo "✅ Done with $pkg"
+          done
+        env:
+          PYPI_PUBLISH_TOKEN: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "🧹 Cleaning up uv cache..."
+          uv cache dir
+          uv cache prune
+          echo "🗑️ Deleting temporary files..."
+          rm -rf packages_to_publish.txt tag_verification_issues.txt

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,7 @@ on:
         default: true
         type: boolean
       publish_url:
-        description: 'PyPI publish URL (leave empty for production PyPI)'
+        description: 'PyPI publish URL (use https://test.pypi.org/legacy/ for TestPyPI)'
         required: false
         default: 'https://test.pypi.org/legacy/'
         type: string
@@ -18,549 +18,179 @@ on:
         required: false
         default: true
         type: boolean
-      generate_changelog:
-        description: 'Generate changelog for published packages'
-        required: false
-        default: true
-        type: boolean
-      notify_on_completion:
-        description: 'Send notification on completion'
-        required: false
-        default: false
-        type: boolean
-      concurrent_build:
-        description: 'Build packages concurrently'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # Required for trusted publishing to PyPI
+      id-token: write # Required for trusted publishing to PyPI
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Needed for tag verification
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install uv
-        run: |
-          pip install uv
-          uv --version
-
-      - name: Install dependencies for version checking
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tomlkit requests
+          pip install uv tomlkit requests
 
       - name: Find packages with updated versions
         id: find-packages
         env:
+          # Pass publish URL to script to check against TestPyPI if needed
           CHECK_TEST_PYPI: ${{ inputs.publish_url == 'https://test.pypi.org/legacy/' }}
           VERIFY_TAGS: ${{ inputs.verify_tags }}
         run: |
           python -m scripts.find_updated_packages
           if [ -f packages_to_publish.txt ]; then
+            # Store comma-separated list and count as outputs
             echo "packages_to_publish=$(cat packages_to_publish.txt)" >> $GITHUB_OUTPUT
-            echo "packages_count=$(cat packages_to_publish.txt | tr ',' '\n' | wc -l)" >> $GITHUB_OUTPUT
+            echo "packages_count=$(wc -w < packages_to_publish.txt | tr -d ' ')" >> $GITHUB_OUTPUT # Count words (packages)
           else
             echo "packages_to_publish=" >> $GITHUB_OUTPUT
             echo "packages_count=0" >> $GITHUB_OUTPUT
           fi
           
+          # Check if tag verification found issues
           if [ -f tag_verification_issues.txt ]; then
             echo "has_tag_issues=true" >> $GITHUB_OUTPUT
           else
             echo "has_tag_issues=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate Changelog
-        if: inputs.generate_changelog == true && steps.find-packages.outputs.packages_to_publish != ''
-        id: changelog
-        run: |
-          mkdir -p changelogs
-          
-          # Read the list of packages to publish
-          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-          
-          for package in "${PACKAGES[@]}"; do
-            echo "Generating changelog for $package"
-            
-            # Determine package name and version
-            if [ "$package" = "feluda" ]; then
-              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('pyproject.toml').read())['project']['version'])")
-            else
-              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('$package/pyproject.toml').read())['project']['version'])")
-            fi
-            
-            PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
-            PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
-            
-            # Get the git tag for the current version
-            if [ "$package" = "feluda" ]; then
-              TAG_FORMAT=$(python -c "import tomlkit; data=tomlkit.parse(open('pyproject.toml').read()); print(data.get('tool', {}).get('semantic_release', {}).get('branches', {}).get('main', {}).get('tag_format', '{name}-{version}'))")
-            else
-              TAG_FORMAT=$(python -c "import tomlkit; data=tomlkit.parse(open('$package/pyproject.toml').read()); print(data.get('tool', {}).get('semantic_release', {}).get('branches', {}).get('main', {}).get('tag_format', '{name}-{version}'))")
-            fi
-            
-            CURRENT_TAG=$(echo $TAG_FORMAT | sed "s/{name}/$PACKAGE_NAME/g" | sed "s/{version}/$PACKAGE_VERSION/g")
-            
-            # Find the previous tag
-            ALL_TAGS=$(git tag -l "$PACKAGE_NAME-*" | sort -V)
-            PREVIOUS_TAG=$(echo "$ALL_TAGS" | grep -v "$CURRENT_TAG" | tail -n 1)
-            
-            if [ -z "$PREVIOUS_TAG" ]; then
-              echo "No previous tag found for $PACKAGE_NAME, using first commit"
-              COMMIT_RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
-            else
-              echo "Previous tag: $PREVIOUS_TAG, Current tag: $CURRENT_TAG"
-              COMMIT_RANGE="$PREVIOUS_TAG..$CURRENT_TAG"
-            fi
-            
-            # Generate changelog
-            echo "# Changelog for $PACKAGE_NAME v$PACKAGE_VERSION" > "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            echo "## Changes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            
-            # Add sections for different types of changes
-            if [ "$package" = "feluda" ]; then
-              COMMITS=$(git log $COMMIT_RANGE --pretty=format:"%s (%h)" --no-merges -- "feluda/" "pyproject.toml")
-            else
-              COMMITS=$(git log $COMMIT_RANGE --pretty=format:"%s (%h)" --no-merges -- "$package/")
-            fi
-            
-            # Extract different types of commits
-            FEATURES=$(echo "$COMMITS" | grep -i "^feat" || echo "")
-            FIXES=$(echo "$COMMITS" | grep -i "^fix" || echo "")
-            DOCS=$(echo "$COMMITS" | grep -i "^docs" || echo "")
-            CHORE=$(echo "$COMMITS" | grep -i "^chore" || echo "")
-            OTHER=$(echo "$COMMITS" | grep -iv "^feat" | grep -iv "^fix" | grep -iv "^docs" | grep -iv "^chore" || echo "")
-            
-            # Add the sections if they have any commits
-            if [ -n "$FEATURES" ]; then
-              echo "### Features" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$FEATURES" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            if [ -n "$FIXES" ]; then
-              echo "### Bug Fixes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$FIXES" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            if [ -n "$DOCS" ]; then
-              echo "### Documentation" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$DOCS" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            if [ -n "$CHORE" ]; then
-              echo "### Chores" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$CHORE" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            if [ -n "$OTHER" ]; then
-              echo "### Other Changes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$OTHER" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            # Add contributors
-            if [ "$package" = "feluda" ]; then
-              CONTRIBUTORS=$(git log $COMMIT_RANGE --pretty=format:"%an" --no-merges -- "feluda/" "pyproject.toml" | sort -u)
-            else
-              CONTRIBUTORS=$(git log $COMMIT_RANGE --pretty=format:"%an" --no-merges -- "$package/" | sort -u)
-            fi
-            
-            if [ -n "$CONTRIBUTORS" ]; then
-              echo "### Contributors" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-              echo "$CONTRIBUTORS" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
-            fi
-            
-            echo "Generated changelog for $PACKAGE_NAME v$PACKAGE_VERSION"
-          done
-          
-          echo "changelogs_generated=true" >> $GITHUB_OUTPUT
-
-      - name: Check Dependencies
-        if: steps.find-packages.outputs.packages_to_publish != ''
-        id: check-deps
-        run: |
-          # Read the list of packages to publish
-          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-          
-          HAS_DEPENDENCY_ISSUES=false
-          
-          for package in "${PACKAGES[@]}"; do
-            echo "Checking dependencies for $package"
-            
-            # Run a basic pip check for the package
-            if [ "$package" = "feluda" ]; then
-              pip install -e . || true
-            else
-              cd "$package" || continue
-              pip install -e . || true
-              cd - > /dev/null
-            fi
-            
-            # Check for any dependency issues using pip check
-            pip check 2> dependency_issues.txt || HAS_DEPENDENCY_ISSUES=true
-            
-            if [ "$HAS_DEPENDENCY_ISSUES" = "true" ]; then
-              echo "Dependency issues found in $package:"
-              cat dependency_issues.txt
-              echo "⚠️ Warning: Dependency issues detected in $package. See logs for details."
-            fi
-          done
-          
-          echo "has_dependency_issues=$HAS_DEPENDENCY_ISSUES" >> $GITHUB_OUTPUT
-
-      - name: Build and Publish to PyPI
+      - name: Build packages
+        # Run only if there are packages to publish
         if: steps.find-packages.outputs.packages_to_publish != ''
         env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          # Target repository URL (TestPyPI or Production)
           PUBLISH_URL: ${{ inputs.publish_url }}
-          CONCURRENT_BUILD: ${{ inputs.concurrent_build }}
         run: |
+          set -e # Exit on any error
+
           # Read the list of packages to publish
           IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
           
-          # Create a clean dist directory
+          # Clean slate for build artifacts
           rm -rf dist dist_backup
           mkdir -p dist
           
-          # Display warning if tag issues were found
+          # Display warnings from previous steps
           if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
-            echo "⚠️ Warning: Some packages have tag verification issues. See tag_verification_issues.txt for details."
-            cat tag_verification_issues.txt || true
+            echo "::warning::Some packages have tag verification issues. See 'Find packages' step logs."
+            cat tag_verification_issues.txt || true # Display if exists
           fi
           
-          # Display warning if dependency issues were found
-          if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
-            echo "⚠️ Warning: Dependency issues detected. Publishing may result in packages that are difficult to install."
-          fi
-          
-          # Process packages differently based on concurrent_build setting
-          if [ "$CONCURRENT_BUILD" = "true" ]; then
-            echo "Building packages concurrently..."
+          # Build packages sequentially
+          echo "Building packages..."
+          for package_path in "${PACKAGES[@]}"; do
+            echo "--- Processing package: $package_path ---"
             
-            # Install GNU parallel for concurrent processing
-            apt-get update && apt-get install -y parallel
-            
-            # Use parallel to build packages concurrently
-            mkdir -p temp_build_scripts
-            
-            for package in "${PACKAGES[@]}"; do
-              echo "Creating build script for $package"
-              
-              if [ "$package" = "feluda" ]; then
-                # Script for building root feluda package
-                cat > "temp_build_scripts/build_${package//\//_}.sh" << EOL
-#!/bin/bash
-echo "Building root feluda package from repository root"
-cd $PWD
-uv build --index-strategy unsafe-best-match
-mkdir -p dist_backup/feluda
-cp dist/* dist_backup/feluda/ || true
-echo "Finished building feluda"
-EOL
-              else
-                # Script for building operator package
-                cat > "temp_build_scripts/build_${package//\//_}.sh" << EOL
-#!/bin/bash
-echo "Building package: $package"
-cd $PWD/$package
-uv build --index-strategy unsafe-best-match
-mkdir -p $PWD/dist_backup/$package
-cp $PWD/dist/* $PWD/dist_backup/$package/ || true
-echo "Finished building $package"
-EOL
-              fi
-              
-              chmod +x "temp_build_scripts/build_${package//\//_}.sh"
-            done
-            
-            # Run the build scripts in parallel
-            ls temp_build_scripts/*.sh | parallel -j$(nproc) bash || true
-            
-            # Combine all built packages into the dist directory
-            mkdir -p dist
-            cp -R dist_backup/*/* dist/ || true
-            
-            # Publish all packages at once
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "DRY RUN: Would publish all packages to $PUBLISH_URL"
-              echo "Files that would be published:"
-              ls -la dist/
+            if [ "$package_path" = "." ] || [ "$package_path" = "feluda" ]; then
+              echo "Building root package (.)"
+              uv build --index-strategy unsafe-best-match
             else
-              echo "LIVE RUN: Publishing all packages to $PUBLISH_URL"
-              if [ -n "$PUBLISH_URL" ]; then
-                uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-              else
-                uv publish --token "$PYPI_TOKEN"
-              fi
+              echo "Building package: $package_path"
+              ( # Subshell for cd
+                cd "$package_path" || exit 1
+                uv build --index-strategy unsafe-best-match # Builds in root dist
+              )
             fi
             
-          else
-            echo "Building packages sequentially..."
-            
-            for package in "${PACKAGES[@]}"; do
-              echo "Processing package: $package"
-              
-              # Special handling for the main feluda package which has pyproject.toml in the root
-              if [ "$package" = "feluda" ]; then
-                echo "Building root feluda package from repository root"
-                # Build from the root directory
-                uv build --index-strategy unsafe-best-match
-                
-                if [ "$DRY_RUN" = "true" ]; then
-                  echo "DRY RUN: Would publish feluda to $PUBLISH_URL"
-                  # Just list the files that would be published without actually uploading
-                  echo "Files that would be published:"
-                  ls -la dist/
-                else
-                  echo "LIVE RUN: Publishing feluda to $PUBLISH_URL"
-                  if [ -n "$PUBLISH_URL" ]; then
-                    uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-                  else
-                    uv publish --token "$PYPI_TOKEN"
-                  fi
-                fi
-              else
-                # Normal handling for operator packages that have their own pyproject.toml
-                cd "$package" || exit 1
-                
-                echo "Building package: $package"
-                # Build the package - note that uv build will create the dist directory in the repository root
-                # rather than in the package directory
-                uv build --index-strategy unsafe-best-match
-                
-                # Navigate back to the root for publishing
-                cd - > /dev/null
-                
-                if [ "$DRY_RUN" = "true" ]; then
-                  echo "DRY RUN: Would publish $package to $PUBLISH_URL"
-                  # Just list the files that would be published without actually uploading
-                  echo "Files that would be published:"
-                  ls -la dist/
-                else
-                  echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
-                  if [ -n "$PUBLISH_URL" ]; then
-                    uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-                  else
-                    uv publish --token "$PYPI_TOKEN"
-                  fi
-                fi
-              fi
-              
-              # Move the built artifacts to a backup directory for this package
-              mkdir -p "dist_backup/$package"
-              mv dist/* "dist_backup/$package/" || true
-              
-              # Clean the dist directory for the next package
-              rm -rf dist
-              mkdir -p dist
-            done
-          fi
-
-      - name: Verify Published Packages
-        if: inputs.dry_run == false && steps.find-packages.outputs.packages_to_publish != ''
-        id: verify
-        run: |
-          echo "Giving PyPI some time to index the newly published packages..."
-          sleep 30
-          
-          # Read the list of packages to publish
-          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-          
-          # Create a temp directory for verification
-          mkdir -p verification_env
-          cd verification_env
-          python -m venv venv
-          source venv/bin/activate
-          
-          VERIFICATION_FAILED=false
-          
-          for package in "${PACKAGES[@]}"; do
-            if [ "$package" = "feluda" ]; then
-              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('../pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('../pyproject.toml').read())['project']['version'])")
-            else
-              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('../$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('../$package/pyproject.toml').read())['project']['version'])")
+            # Check for build success by checking if files were created
+            if [ ! "$(ls -A dist 2>/dev/null)" ]; then
+              echo "::error::No artifacts were created for $package_path"
+              exit 1
             fi
             
-            PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
-            PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
-            
-            echo "Verifying $PACKAGE_NAME==$PACKAGE_VERSION can be installed from PyPI..."
-            
-            # Try to install from the configured PyPI (test or production)
-            if [ -n "${{ inputs.publish_url }}" ]; then
-              # Using Test PyPI
-              pip install --index-url "https://test.pypi.org/simple/" --extra-index-url "https://pypi.org/simple/" "$PACKAGE_NAME==$PACKAGE_VERSION" > install_log.txt 2>&1 || VERIFICATION_FAILED=true
-            else
-              # Using Production PyPI
-              pip install "$PACKAGE_NAME==$PACKAGE_VERSION" > install_log.txt 2>&1 || VERIFICATION_FAILED=true
-            fi
-            
-            if [ "$VERIFICATION_FAILED" = "true" ]; then
-              echo "❌ Failed to verify installation of $PACKAGE_NAME==$PACKAGE_VERSION"
-              cat install_log.txt
-            else
-              echo "✅ Successfully verified $PACKAGE_NAME==$PACKAGE_VERSION can be installed"
-            fi
+            echo "Build successful for $package_path"
           done
           
-          cd ..
-          rm -rf verification_env
-          
-          echo "verification_success=$([ "$VERIFICATION_FAILED" = "false" ] && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+          echo "Contents of dist/ directory:"
+          ls -lR dist/
 
-      - name: Send Notification
-        if: inputs.notify_on_completion == true
+      - name: Publish to PyPI
+        # Run only if packages were built and not in dry-run mode
+        if: steps.find-packages.outputs.packages_to_publish != '' && inputs.dry_run == false
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PUBLISH_URL: ${{ inputs.publish_url }}
         run: |
-          echo "Preparing notification..."
+          set -e # Exit on any error
           
-          # Format the notification message
-          MESSAGE="🚀 PyPI Publishing Report\n\n"
+          # Check if dist directory is not empty
+          if [ ! "$(ls -A dist)" ]; then
+            echo "::error::Dist directory is empty. No packages to publish."
+            exit 1
+          fi
           
-          if [ "${{ steps.find-packages.outputs.packages_count }}" = "0" ]; then
-            MESSAGE="${MESSAGE}No packages were published.\n"
+          echo "Publishing packages to ${PUBLISH_URL:-PyPI Production}..."
+          
+          # Use uv publish with the target URL and token
+          if [ -n "$PUBLISH_URL" ]; then
+            # Publish to specified URL (e.g., TestPyPI)
+            uv publish dist/* --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
           else
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
-              MESSAGE="${MESSAGE}DRY RUN: ${{ steps.find-packages.outputs.packages_count }} packages were processed (no actual publishing).\n"
-            else
-              MESSAGE="${MESSAGE}${{ steps.find-packages.outputs.packages_count }} packages were published to ${{ inputs.publish_url || 'PyPI (production)' }}.\n"
-              
-              if [ "${{ steps.verify.outputs.verification_success }}" = "true" ]; then
-                MESSAGE="${MESSAGE}✅ All packages were verified installable.\n"
-              else
-                MESSAGE="${MESSAGE}⚠️ Some packages could not be verified. See logs for details.\n"
-              fi
-            fi
-            
-            # Add packages list
-            MESSAGE="${MESSAGE}\nPackages:\n"
-            IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-            for package in "${PACKAGES[@]}"; do
-              MESSAGE="${MESSAGE}- $package\n"
-            done
+            # Publish to production PyPI
+            uv publish dist/* --token "$PYPI_TOKEN"
           fi
           
-          # Add changelog info if generated
-          if [ "${{ steps.changelog.outputs.changelogs_generated }}" = "true" ]; then
-            MESSAGE="${MESSAGE}\nChangelogs were generated for all packages.\n"
-          fi
-          
-          # Include any warnings
-          if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
-            MESSAGE="${MESSAGE}\n⚠️ Warning: Some packages had git tag verification issues.\n"
-          fi
-          
-          if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
-            MESSAGE="${MESSAGE}\n⚠️ Warning: Dependency issues were detected.\n"
-          fi
-          
-          echo -e "$MESSAGE"
-          
-          # In a real implementation, you would send this to Slack, Discord, or email
-          # For example, using a webhook:
-          # curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" ${{ secrets.WEBHOOK_URL }}
-          
-          echo "Notification prepared. In a real implementation, this would be sent to a notification service."
+          echo "Publish command completed successfully."
+
+      - name: Upload Artifacts
+        # Run only if packages were processed
+        if: steps.find-packages.outputs.packages_to_publish != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            dist/ # Contains wheels/sdists
+            packages_to_publish.txt # List of packages processed
+            tag_verification_issues.txt # Optional: Issues found during tag check
+          retention-days: 3
+          if-no-files-found: warn
 
       - name: Summary
+        # Always run to provide a summary
         run: |
           echo "## Publish to PyPI Summary" >> $GITHUB_STEP_SUMMARY
           
           if [ -z "${{ steps.find-packages.outputs.packages_to_publish }}" ]; then
-            echo "No packages needed to be published." >> $GITHUB_STEP_SUMMARY
+            echo "No packages required publishing based on version checks." >> $GITHUB_STEP_SUMMARY
           else
+            PUBLISH_DESTINATION="${{ inputs.publish_url }}"
+            if [ -z "$PUBLISH_DESTINATION" ]; then PUBLISH_DESTINATION="PyPI Production"; fi
+
             if [ "${{ inputs.dry_run }}" = "true" ]; then
               echo "### 🧪 DRY RUN MODE" >> $GITHUB_STEP_SUMMARY
-              echo "The following packages were processed (no actual publishing):" >> $GITHUB_STEP_SUMMARY
+              echo "The following **${{ steps.find-packages.outputs.packages_count }}** package(s) were processed for **$PUBLISH_DESTINATION** (no actual publishing):" >> $GITHUB_STEP_SUMMARY
             else
               echo "### 🚀 LIVE PUBLISHING MODE" >> $GITHUB_STEP_SUMMARY
-              destination="${{ inputs.publish_url }}"
-              if [ -z "$destination" ]; then
-                destination="PyPI (production)"
-              fi
-              echo "The following packages were published to $destination:" >> $GITHUB_STEP_SUMMARY
+              echo "Attempted to publish the following **${{ steps.find-packages.outputs.packages_count }}** package(s) to **$PUBLISH_DESTINATION**:" >> $GITHUB_STEP_SUMMARY
             fi
             
+            # List packages
             IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
-            
-            for package in "${PACKAGES[@]}"; do
-              if [ "$package" = "feluda" ]; then
-                PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('pyproject.toml').read())['project']['version'])")
-              else
-                PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('$package/pyproject.toml').read())['project']['version'])")
-              fi
-              
+            for package_path in "${PACKAGES[@]}"; do
+              # Get package name/version again for display
+              if [ "$package_path" = "." ] || [ "$package_path" = "feluda" ]; then PYPROJECT_PATH="pyproject.toml"; else PYPROJECT_PATH="$package_path/pyproject.toml"; fi
+              PACKAGE_INFO=$(python -c "import sys, tomlkit; data=tomlkit.parse(open('$PYPROJECT_PATH').read()); print(data['project']['name'] + ',' + data['project']['version'])")
               PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
               PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
               
-              echo "- **$PACKAGE_NAME** (v$PACKAGE_VERSION) from `$package`" >> $GITHUB_STEP_SUMMARY
-              
-              # If changelogs were generated, include them
-              if [ "${{ steps.changelog.outputs.changelogs_generated }}" = "true" ] && [ -f "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md" ]; then
-                echo "" >> $GITHUB_STEP_SUMMARY
-                echo "<details><summary>Changelog for $PACKAGE_NAME v$PACKAGE_VERSION</summary>" >> $GITHUB_STEP_SUMMARY
-                echo "" >> $GITHUB_STEP_SUMMARY
-                cat "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md" >> $GITHUB_STEP_SUMMARY
-                echo "" >> $GITHUB_STEP_SUMMARY
-                echo "</details>" >> $GITHUB_STEP_SUMMARY
-              fi
+              echo "- **$PACKAGE_NAME** v$PACKAGE_VERSION (from \`$package_path\`)" >> $GITHUB_STEP_SUMMARY
             done
             
-            echo "" >> $GITHUB_STEP_SUMMARY
-            
-            # Add verification results
-            if [ "${{ inputs.dry_run }}" = "false" ] && [ -n "${{ steps.verify.outputs.verification_success }}" ]; then
-              if [ "${{ steps.verify.outputs.verification_success }}" = "true" ]; then
-                echo "### ✅ Verification" >> $GITHUB_STEP_SUMMARY
-                echo "All packages were verified to be installable from PyPI." >> $GITHUB_STEP_SUMMARY
-              else
-                echo "### ⚠️ Verification" >> $GITHUB_STEP_SUMMARY
-                echo "Some packages could not be verified. See logs for details." >> $GITHUB_STEP_SUMMARY
-              fi
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-            
-            # Add warnings section if needed
-            if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ] || [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
+            # Add warnings
+            if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
               echo "### ⚠️ Warnings" >> $GITHUB_STEP_SUMMARY
-              
-              if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
-                echo "- Some packages had git tag verification issues. See workflow logs for details." >> $GITHUB_STEP_SUMMARY
-              fi
-              
-              if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
-                echo "- Dependency issues were detected. See workflow logs for details." >> $GITHUB_STEP_SUMMARY
-              fi
+              echo "- Git tag verification issues detected. See logs and artifacts." >> $GITHUB_STEP_SUMMARY
             fi
           fi
-
-      - name: Upload Artifacts
-        if: steps.find-packages.outputs.packages_to_publish != ''
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-artifacts
-          path: |
-            dist_backup/
-            changelogs/
-            packages_to_publish.txt
-            tag_verification_issues.txt
-          retention-days: 7

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,26 @@ on:
         required: false
         default: 'https://test.pypi.org/legacy/'
         type: string
+      verify_tags:
+        description: 'Verify package versions match git tags'
+        required: false
+        default: true
+        type: boolean
+      generate_changelog:
+        description: 'Generate changelog for published packages'
+        required: false
+        default: true
+        type: boolean
+      notify_on_completion:
+        description: 'Send notification on completion'
+        required: false
+        default: false
+        type: boolean
+      concurrent_build:
+        description: 'Build packages concurrently'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   publish:
@@ -46,13 +66,166 @@ jobs:
         id: find-packages
         env:
           CHECK_TEST_PYPI: ${{ inputs.publish_url == 'https://test.pypi.org/legacy/' }}
+          VERIFY_TAGS: ${{ inputs.verify_tags }}
         run: |
           python -m scripts.find_updated_packages
           if [ -f packages_to_publish.txt ]; then
             echo "packages_to_publish=$(cat packages_to_publish.txt)" >> $GITHUB_OUTPUT
+            echo "packages_count=$(cat packages_to_publish.txt | tr ',' '\n' | wc -l)" >> $GITHUB_OUTPUT
           else
             echo "packages_to_publish=" >> $GITHUB_OUTPUT
+            echo "packages_count=0" >> $GITHUB_OUTPUT
           fi
+          
+          if [ -f tag_verification_issues.txt ]; then
+            echo "has_tag_issues=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_tag_issues=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate Changelog
+        if: inputs.generate_changelog == true && steps.find-packages.outputs.packages_to_publish != ''
+        id: changelog
+        run: |
+          mkdir -p changelogs
+          
+          # Read the list of packages to publish
+          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+          
+          for package in "${PACKAGES[@]}"; do
+            echo "Generating changelog for $package"
+            
+            # Determine package name and version
+            if [ "$package" = "feluda" ]; then
+              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('pyproject.toml').read())['project']['version'])")
+            else
+              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('$package/pyproject.toml').read())['project']['version'])")
+            fi
+            
+            PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
+            PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
+            
+            # Get the git tag for the current version
+            if [ "$package" = "feluda" ]; then
+              TAG_FORMAT=$(python -c "import tomlkit; data=tomlkit.parse(open('pyproject.toml').read()); print(data.get('tool', {}).get('semantic_release', {}).get('branches', {}).get('main', {}).get('tag_format', '{name}-{version}'))")
+            else
+              TAG_FORMAT=$(python -c "import tomlkit; data=tomlkit.parse(open('$package/pyproject.toml').read()); print(data.get('tool', {}).get('semantic_release', {}).get('branches', {}).get('main', {}).get('tag_format', '{name}-{version}'))")
+            fi
+            
+            CURRENT_TAG=$(echo $TAG_FORMAT | sed "s/{name}/$PACKAGE_NAME/g" | sed "s/{version}/$PACKAGE_VERSION/g")
+            
+            # Find the previous tag
+            ALL_TAGS=$(git tag -l "$PACKAGE_NAME-*" | sort -V)
+            PREVIOUS_TAG=$(echo "$ALL_TAGS" | grep -v "$CURRENT_TAG" | tail -n 1)
+            
+            if [ -z "$PREVIOUS_TAG" ]; then
+              echo "No previous tag found for $PACKAGE_NAME, using first commit"
+              COMMIT_RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
+            else
+              echo "Previous tag: $PREVIOUS_TAG, Current tag: $CURRENT_TAG"
+              COMMIT_RANGE="$PREVIOUS_TAG..$CURRENT_TAG"
+            fi
+            
+            # Generate changelog
+            echo "# Changelog for $PACKAGE_NAME v$PACKAGE_VERSION" > "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            echo "## Changes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            
+            # Add sections for different types of changes
+            if [ "$package" = "feluda" ]; then
+              COMMITS=$(git log $COMMIT_RANGE --pretty=format:"%s (%h)" --no-merges -- "feluda/" "pyproject.toml")
+            else
+              COMMITS=$(git log $COMMIT_RANGE --pretty=format:"%s (%h)" --no-merges -- "$package/")
+            fi
+            
+            # Extract different types of commits
+            FEATURES=$(echo "$COMMITS" | grep -i "^feat" || echo "")
+            FIXES=$(echo "$COMMITS" | grep -i "^fix" || echo "")
+            DOCS=$(echo "$COMMITS" | grep -i "^docs" || echo "")
+            CHORE=$(echo "$COMMITS" | grep -i "^chore" || echo "")
+            OTHER=$(echo "$COMMITS" | grep -iv "^feat" | grep -iv "^fix" | grep -iv "^docs" | grep -iv "^chore" || echo "")
+            
+            # Add the sections if they have any commits
+            if [ -n "$FEATURES" ]; then
+              echo "### Features" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$FEATURES" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            if [ -n "$FIXES" ]; then
+              echo "### Bug Fixes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$FIXES" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            if [ -n "$DOCS" ]; then
+              echo "### Documentation" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$DOCS" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            if [ -n "$CHORE" ]; then
+              echo "### Chores" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$CHORE" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            if [ -n "$OTHER" ]; then
+              echo "### Other Changes" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$OTHER" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            # Add contributors
+            if [ "$package" = "feluda" ]; then
+              CONTRIBUTORS=$(git log $COMMIT_RANGE --pretty=format:"%an" --no-merges -- "feluda/" "pyproject.toml" | sort -u)
+            else
+              CONTRIBUTORS=$(git log $COMMIT_RANGE --pretty=format:"%an" --no-merges -- "$package/" | sort -u)
+            fi
+            
+            if [ -n "$CONTRIBUTORS" ]; then
+              echo "### Contributors" >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+              echo "$CONTRIBUTORS" | sed 's/^/* /' >> "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md"
+            fi
+            
+            echo "Generated changelog for $PACKAGE_NAME v$PACKAGE_VERSION"
+          done
+          
+          echo "changelogs_generated=true" >> $GITHUB_OUTPUT
+
+      - name: Check Dependencies
+        if: steps.find-packages.outputs.packages_to_publish != ''
+        id: check-deps
+        run: |
+          # Read the list of packages to publish
+          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+          
+          HAS_DEPENDENCY_ISSUES=false
+          
+          for package in "${PACKAGES[@]}"; do
+            echo "Checking dependencies for $package"
+            
+            # Run a basic pip check for the package
+            if [ "$package" = "feluda" ]; then
+              pip install -e . || true
+            else
+              cd "$package" || continue
+              pip install -e . || true
+              cd - > /dev/null
+            fi
+            
+            # Check for any dependency issues using pip check
+            pip check 2> dependency_issues.txt || HAS_DEPENDENCY_ISSUES=true
+            
+            if [ "$HAS_DEPENDENCY_ISSUES" = "true" ]; then
+              echo "Dependency issues found in $package:"
+              cat dependency_issues.txt
+              echo "⚠️ Warning: Dependency issues detected in $package. See logs for details."
+            fi
+          done
+          
+          echo "has_dependency_issues=$HAS_DEPENDENCY_ISSUES" >> $GITHUB_OUTPUT
 
       - name: Build and Publish to PyPI
         if: steps.find-packages.outputs.packages_to_publish != ''
@@ -60,71 +233,253 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
           PUBLISH_URL: ${{ inputs.publish_url }}
+          CONCURRENT_BUILD: ${{ inputs.concurrent_build }}
         run: |
           # Read the list of packages to publish
           IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
           
           # Create a clean dist directory
-          rm -rf dist
+          rm -rf dist dist_backup
           mkdir -p dist
           
-          for package in "${PACKAGES[@]}"; do
-            echo "Processing package: $package"
+          # Display warning if tag issues were found
+          if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
+            echo "⚠️ Warning: Some packages have tag verification issues. See tag_verification_issues.txt for details."
+            cat tag_verification_issues.txt || true
+          fi
+          
+          # Display warning if dependency issues were found
+          if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
+            echo "⚠️ Warning: Dependency issues detected. Publishing may result in packages that are difficult to install."
+          fi
+          
+          # Process packages differently based on concurrent_build setting
+          if [ "$CONCURRENT_BUILD" = "true" ]; then
+            echo "Building packages concurrently..."
             
-            # Special handling for the main feluda package which has pyproject.toml in the root
-            if [ "$package" = "feluda" ]; then
-              echo "Building root feluda package from repository root"
-              # Build from the root directory
-              uv build --index-strategy unsafe-best-match
+            # Install GNU parallel for concurrent processing
+            apt-get update && apt-get install -y parallel
+            
+            # Use parallel to build packages concurrently
+            mkdir -p temp_build_scripts
+            
+            for package in "${PACKAGES[@]}"; do
+              echo "Creating build script for $package"
               
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "DRY RUN: Would publish feluda to $PUBLISH_URL"
-                # Just list the files that would be published without actually uploading
-                echo "Files that would be published:"
-                ls -la dist/
+              if [ "$package" = "feluda" ]; then
+                # Script for building root feluda package
+                cat > "temp_build_scripts/build_${package//\//_}.sh" << EOL
+#!/bin/bash
+echo "Building root feluda package from repository root"
+cd $PWD
+uv build --index-strategy unsafe-best-match
+mkdir -p dist_backup/feluda
+cp dist/* dist_backup/feluda/ || true
+echo "Finished building feluda"
+EOL
               else
-                echo "LIVE RUN: Publishing feluda to $PUBLISH_URL"
-                if [ -n "$PUBLISH_URL" ]; then
-                  uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-                else
-                  uv publish --token "$PYPI_TOKEN"
-                fi
+                # Script for building operator package
+                cat > "temp_build_scripts/build_${package//\//_}.sh" << EOL
+#!/bin/bash
+echo "Building package: $package"
+cd $PWD/$package
+uv build --index-strategy unsafe-best-match
+mkdir -p $PWD/dist_backup/$package
+cp $PWD/dist/* $PWD/dist_backup/$package/ || true
+echo "Finished building $package"
+EOL
               fi
+              
+              chmod +x "temp_build_scripts/build_${package//\//_}.sh"
+            done
+            
+            # Run the build scripts in parallel
+            ls temp_build_scripts/*.sh | parallel -j$(nproc) bash || true
+            
+            # Combine all built packages into the dist directory
+            mkdir -p dist
+            cp -R dist_backup/*/* dist/ || true
+            
+            # Publish all packages at once
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY RUN: Would publish all packages to $PUBLISH_URL"
+              echo "Files that would be published:"
+              ls -la dist/
             else
-              # Normal handling for operator packages that have their own pyproject.toml
-              cd "$package" || exit 1
-              
-              echo "Building package: $package"
-              # Build the package - note that uv build will create the dist directory in the repository root
-              # rather than in the package directory
-              uv build --index-strategy unsafe-best-match
-              
-              # Navigate back to the root for publishing
-              cd - > /dev/null
-              
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "DRY RUN: Would publish $package to $PUBLISH_URL"
-                # Just list the files that would be published without actually uploading
-                echo "Files that would be published:"
-                ls -la dist/
+              echo "LIVE RUN: Publishing all packages to $PUBLISH_URL"
+              if [ -n "$PUBLISH_URL" ]; then
+                uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
               else
-                echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
-                if [ -n "$PUBLISH_URL" ]; then
-                  uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
-                else
-                  uv publish --token "$PYPI_TOKEN"
-                fi
+                uv publish --token "$PYPI_TOKEN"
               fi
             fi
             
-            # Move the built artifacts to a backup directory for this package
-            mkdir -p "dist_backup/$package"
-            mv dist/* "dist_backup/$package/" || true
+          else
+            echo "Building packages sequentially..."
             
-            # Clean the dist directory for the next package
-            rm -rf dist
-            mkdir -p dist
+            for package in "${PACKAGES[@]}"; do
+              echo "Processing package: $package"
+              
+              # Special handling for the main feluda package which has pyproject.toml in the root
+              if [ "$package" = "feluda" ]; then
+                echo "Building root feluda package from repository root"
+                # Build from the root directory
+                uv build --index-strategy unsafe-best-match
+                
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "DRY RUN: Would publish feluda to $PUBLISH_URL"
+                  # Just list the files that would be published without actually uploading
+                  echo "Files that would be published:"
+                  ls -la dist/
+                else
+                  echo "LIVE RUN: Publishing feluda to $PUBLISH_URL"
+                  if [ -n "$PUBLISH_URL" ]; then
+                    uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+                  else
+                    uv publish --token "$PYPI_TOKEN"
+                  fi
+                fi
+              else
+                # Normal handling for operator packages that have their own pyproject.toml
+                cd "$package" || exit 1
+                
+                echo "Building package: $package"
+                # Build the package - note that uv build will create the dist directory in the repository root
+                # rather than in the package directory
+                uv build --index-strategy unsafe-best-match
+                
+                # Navigate back to the root for publishing
+                cd - > /dev/null
+                
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "DRY RUN: Would publish $package to $PUBLISH_URL"
+                  # Just list the files that would be published without actually uploading
+                  echo "Files that would be published:"
+                  ls -la dist/
+                else
+                  echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
+                  if [ -n "$PUBLISH_URL" ]; then
+                    uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+                  else
+                    uv publish --token "$PYPI_TOKEN"
+                  fi
+                fi
+              fi
+              
+              # Move the built artifacts to a backup directory for this package
+              mkdir -p "dist_backup/$package"
+              mv dist/* "dist_backup/$package/" || true
+              
+              # Clean the dist directory for the next package
+              rm -rf dist
+              mkdir -p dist
+            done
+          fi
+
+      - name: Verify Published Packages
+        if: inputs.dry_run == false && steps.find-packages.outputs.packages_to_publish != ''
+        id: verify
+        run: |
+          echo "Giving PyPI some time to index the newly published packages..."
+          sleep 30
+          
+          # Read the list of packages to publish
+          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+          
+          # Create a temp directory for verification
+          mkdir -p verification_env
+          cd verification_env
+          python -m venv venv
+          source venv/bin/activate
+          
+          VERIFICATION_FAILED=false
+          
+          for package in "${PACKAGES[@]}"; do
+            if [ "$package" = "feluda" ]; then
+              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('../pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('../pyproject.toml').read())['project']['version'])")
+            else
+              PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('../$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('../$package/pyproject.toml').read())['project']['version'])")
+            fi
+            
+            PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
+            PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
+            
+            echo "Verifying $PACKAGE_NAME==$PACKAGE_VERSION can be installed from PyPI..."
+            
+            # Try to install from the configured PyPI (test or production)
+            if [ -n "${{ inputs.publish_url }}" ]; then
+              # Using Test PyPI
+              pip install --index-url "https://test.pypi.org/simple/" --extra-index-url "https://pypi.org/simple/" "$PACKAGE_NAME==$PACKAGE_VERSION" > install_log.txt 2>&1 || VERIFICATION_FAILED=true
+            else
+              # Using Production PyPI
+              pip install "$PACKAGE_NAME==$PACKAGE_VERSION" > install_log.txt 2>&1 || VERIFICATION_FAILED=true
+            fi
+            
+            if [ "$VERIFICATION_FAILED" = "true" ]; then
+              echo "❌ Failed to verify installation of $PACKAGE_NAME==$PACKAGE_VERSION"
+              cat install_log.txt
+            else
+              echo "✅ Successfully verified $PACKAGE_NAME==$PACKAGE_VERSION can be installed"
+            fi
           done
+          
+          cd ..
+          rm -rf verification_env
+          
+          echo "verification_success=$([ "$VERIFICATION_FAILED" = "false" ] && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+
+      - name: Send Notification
+        if: inputs.notify_on_completion == true
+        run: |
+          echo "Preparing notification..."
+          
+          # Format the notification message
+          MESSAGE="🚀 PyPI Publishing Report\n\n"
+          
+          if [ "${{ steps.find-packages.outputs.packages_count }}" = "0" ]; then
+            MESSAGE="${MESSAGE}No packages were published.\n"
+          else
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              MESSAGE="${MESSAGE}DRY RUN: ${{ steps.find-packages.outputs.packages_count }} packages were processed (no actual publishing).\n"
+            else
+              MESSAGE="${MESSAGE}${{ steps.find-packages.outputs.packages_count }} packages were published to ${{ inputs.publish_url || 'PyPI (production)' }}.\n"
+              
+              if [ "${{ steps.verify.outputs.verification_success }}" = "true" ]; then
+                MESSAGE="${MESSAGE}✅ All packages were verified installable.\n"
+              else
+                MESSAGE="${MESSAGE}⚠️ Some packages could not be verified. See logs for details.\n"
+              fi
+            fi
+            
+            # Add packages list
+            MESSAGE="${MESSAGE}\nPackages:\n"
+            IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+            for package in "${PACKAGES[@]}"; do
+              MESSAGE="${MESSAGE}- $package\n"
+            done
+          fi
+          
+          # Add changelog info if generated
+          if [ "${{ steps.changelog.outputs.changelogs_generated }}" = "true" ]; then
+            MESSAGE="${MESSAGE}\nChangelogs were generated for all packages.\n"
+          fi
+          
+          # Include any warnings
+          if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
+            MESSAGE="${MESSAGE}\n⚠️ Warning: Some packages had git tag verification issues.\n"
+          fi
+          
+          if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
+            MESSAGE="${MESSAGE}\n⚠️ Warning: Dependency issues were detected.\n"
+          fi
+          
+          echo -e "$MESSAGE"
+          
+          # In a real implementation, you would send this to Slack, Discord, or email
+          # For example, using a webhook:
+          # curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" ${{ secrets.WEBHOOK_URL }}
+          
+          echo "Notification prepared. In a real implementation, this would be sent to a notification service."
 
       - name: Summary
         run: |
@@ -133,18 +488,79 @@ jobs:
           if [ -z "${{ steps.find-packages.outputs.packages_to_publish }}" ]; then
             echo "No packages needed to be published." >> $GITHUB_STEP_SUMMARY
           else
-            echo "The following packages were processed:" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "### 🧪 DRY RUN MODE" >> $GITHUB_STEP_SUMMARY
+              echo "The following packages were processed (no actual publishing):" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### 🚀 LIVE PUBLISHING MODE" >> $GITHUB_STEP_SUMMARY
+              destination="${{ inputs.publish_url }}"
+              if [ -z "$destination" ]; then
+                destination="PyPI (production)"
+              fi
+              echo "The following packages were published to $destination:" >> $GITHUB_STEP_SUMMARY
+            fi
+            
             IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
             
             for package in "${PACKAGES[@]}"; do
-              if [ "${{ inputs.dry_run }}" = "true" ]; then
-                echo "- $package (dry run)" >> $GITHUB_STEP_SUMMARY
+              if [ "$package" = "feluda" ]; then
+                PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('pyproject.toml').read())['project']['version'])")
               else
-                destination="${{ inputs.publish_url }}"
-                if [ -z "$destination" ]; then
-                  destination="PyPI (production)"
-                fi
-                echo "- $package (published to $destination)" >> $GITHUB_STEP_SUMMARY
+                PACKAGE_INFO=$(python -c "import tomlkit; print(tomlkit.parse(open('$package/pyproject.toml').read())['project']['name'] + ',' + tomlkit.parse(open('$package/pyproject.toml').read())['project']['version'])")
+              fi
+              
+              PACKAGE_NAME=$(echo $PACKAGE_INFO | cut -d',' -f1)
+              PACKAGE_VERSION=$(echo $PACKAGE_INFO | cut -d',' -f2)
+              
+              echo "- **$PACKAGE_NAME** (v$PACKAGE_VERSION) from `$package`" >> $GITHUB_STEP_SUMMARY
+              
+              # If changelogs were generated, include them
+              if [ "${{ steps.changelog.outputs.changelogs_generated }}" = "true" ] && [ -f "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md" ]; then
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "<details><summary>Changelog for $PACKAGE_NAME v$PACKAGE_VERSION</summary>" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                cat "changelogs/$PACKAGE_NAME-$PACKAGE_VERSION.md" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "</details>" >> $GITHUB_STEP_SUMMARY
               fi
             done
+            
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Add verification results
+            if [ "${{ inputs.dry_run }}" = "false" ] && [ -n "${{ steps.verify.outputs.verification_success }}" ]; then
+              if [ "${{ steps.verify.outputs.verification_success }}" = "true" ]; then
+                echo "### ✅ Verification" >> $GITHUB_STEP_SUMMARY
+                echo "All packages were verified to be installable from PyPI." >> $GITHUB_STEP_SUMMARY
+              else
+                echo "### ⚠️ Verification" >> $GITHUB_STEP_SUMMARY
+                echo "Some packages could not be verified. See logs for details." >> $GITHUB_STEP_SUMMARY
+              fi
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+            
+            # Add warnings section if needed
+            if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ] || [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
+              echo "### ⚠️ Warnings" >> $GITHUB_STEP_SUMMARY
+              
+              if [ "${{ steps.find-packages.outputs.has_tag_issues }}" = "true" ]; then
+                echo "- Some packages had git tag verification issues. See workflow logs for details." >> $GITHUB_STEP_SUMMARY
+              fi
+              
+              if [ "${{ steps.check-deps.outputs.has_dependency_issues }}" = "true" ]; then
+                echo "- Dependency issues were detected. See workflow logs for details." >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
           fi
+
+      - name: Upload Artifacts
+        if: steps.find-packages.outputs.packages_to_publish != ''
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: |
+            dist_backup/
+            changelogs/
+            packages_to_publish.txt
+            tag_verification_issues.txt
+          retention-days: 7

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -64,6 +64,10 @@ jobs:
           # Read the list of packages to publish
           IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
           
+          # Create a clean dist directory
+          rm -rf dist
+          mkdir -p dist
+          
           for package in "${PACKAGES[@]}"; do
             echo "Processing package: $package"
             
@@ -90,10 +94,13 @@ jobs:
               # Normal handling for operator packages that have their own pyproject.toml
               cd "$package" || exit 1
               
-              # Build the package
               echo "Building package: $package"
+              # Build the package - note that uv build will create the dist directory in the repository root
+              # rather than in the package directory
               uv build --index-strategy unsafe-best-match
-              ls -la dist/
+              
+              # Navigate back to the root for publishing
+              cd - > /dev/null
               
               if [ "$DRY_RUN" = "true" ]; then
                 echo "DRY RUN: Would publish $package to $PUBLISH_URL"
@@ -108,9 +115,15 @@ jobs:
                   uv publish --token "$PYPI_TOKEN"
                 fi
               fi
-              
-              cd - > /dev/null
             fi
+            
+            # Move the built artifacts to a backup directory for this package
+            mkdir -p "dist_backup/$package"
+            mv dist/* "dist_backup/$package/" || true
+            
+            # Clean the dist directory for the next package
+            rm -rf dist
+            mkdir -p dist
           done
 
       - name: Summary

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Build packages
         # Run only if there are packages to publish
         if: steps.find-packages.outputs.packages_to_publish != ''
+        id: build-packages
         env:
           # Target repository URL (TestPyPI or Production)
           PUBLISH_URL: ${{ inputs.publish_url }}
@@ -87,6 +88,11 @@ jobs:
             echo "::warning::Some packages have tag verification issues. See 'Find packages' step logs."
             cat tag_verification_issues.txt || true # Display if exists
           fi
+          
+          # Create artifacts directory for saving build info
+          mkdir -p artifacts
+          cp packages_to_publish.txt artifacts/ || echo "packages_to_publish.txt not found"
+          [ -f tag_verification_issues.txt ] && cp tag_verification_issues.txt artifacts/ || echo "No tag verification issues found"
           
           # Build packages sequentially
           echo "Building packages..."
@@ -110,15 +116,21 @@ jobs:
               exit 1
             fi
             
+            # Keep a copy of built artifacts in the artifacts directory
+            mkdir -p "artifacts/dist/$package_path"
+            cp dist/* "artifacts/dist/$package_path/" || true
+            
             echo "Build successful for $package_path"
           done
           
           echo "Contents of dist/ directory:"
           ls -lR dist/
+          
+          echo "has_built_packages=true" >> $GITHUB_OUTPUT
 
       - name: Publish to PyPI
         # Run only if packages were built and not in dry-run mode
-        if: steps.find-packages.outputs.packages_to_publish != '' && inputs.dry_run == false
+        if: steps.build-packages.outputs.has_built_packages == 'true' && inputs.dry_run == false
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           PUBLISH_URL: ${{ inputs.publish_url }}
@@ -150,10 +162,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
-          path: |
-            dist/ # Contains wheels/sdists
-            packages_to_publish.txt # List of packages processed
-            tag_verification_issues.txt # Optional: Issues found during tag check
+          path: artifacts/
           retention-days: 3
           if-no-files-found: warn
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,112 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Perform a dry run (no actual publishing)'
+        required: false
+        default: true
+        type: boolean
+      publish_url:
+        description: 'PyPI publish URL (leave empty for production PyPI)'
+        required: false
+        default: 'https://test.pypi.org/legacy/'
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for trusted publishing to PyPI
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: |
+          pip install uv
+          uv --version
+
+      - name: Install dependencies for version checking
+        run: |
+          python -m pip install --upgrade pip
+          pip install tomlkit requests
+
+      - name: Find packages with updated versions
+        id: find-packages
+        env:
+          CHECK_TEST_PYPI: ${{ inputs.publish_url == 'https://test.pypi.org/legacy/' }}
+        run: |
+          python -m scripts.find_updated_packages
+          if [ -f packages_to_publish.txt ]; then
+            echo "packages_to_publish=$(cat packages_to_publish.txt)" >> $GITHUB_OUTPUT
+          else
+            echo "packages_to_publish=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and Publish to PyPI
+        if: steps.find-packages.outputs.packages_to_publish != ''
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PUBLISH_URL: ${{ inputs.publish_url }}
+        run: |
+          # Read the list of packages to publish
+          IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+          
+          for package in "${PACKAGES[@]}"; do
+            echo "Processing package: $package"
+            cd "$package" || exit 1
+            
+            # Build the package first
+            echo "Building package: $package"
+            uv build --index-strategy unsafe-best-match
+            ls -la dist/
+            
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY RUN: Would publish $package to $PUBLISH_URL"
+              uv publish --no-upload
+            else
+              echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
+              if [ -n "$PUBLISH_URL" ]; then
+                uv publish --publish-url "$PUBLISH_URL" --token "$PYPI_TOKEN"
+              else
+                uv publish --token "$PYPI_TOKEN"
+              fi
+            fi
+            
+            cd - > /dev/null
+          done
+
+      - name: Summary
+        run: |
+          echo "## Publish to PyPI Summary" >> $GITHUB_STEP_SUMMARY
+          
+          if [ -z "${{ steps.find-packages.outputs.packages_to_publish }}" ]; then
+            echo "No packages needed to be published." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "The following packages were processed:" >> $GITHUB_STEP_SUMMARY
+            IFS=',' read -ra PACKAGES <<< "${{ steps.find-packages.outputs.packages_to_publish }}"
+            
+            for package in "${PACKAGES[@]}"; do
+              if [ "${{ inputs.dry_run }}" = "true" ]; then
+                echo "- $package (dry run)" >> $GITHUB_STEP_SUMMARY
+              else
+                destination="${{ inputs.publish_url }}"
+                if [ -z "$destination" ]; then
+                  destination="PyPI (production)"
+                fi
+                echo "- $package (published to $destination)" >> $GITHUB_STEP_SUMMARY
+              fi
+            done
+          fi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -75,7 +75,9 @@ jobs:
             
             if [ "$DRY_RUN" = "true" ]; then
               echo "DRY RUN: Would publish $package to $PUBLISH_URL"
-              uv publish --no-upload
+              # Just list the files that would be published without actually uploading
+              echo "Files that would be published:"
+              ls -la dist/
             else
               echo "LIVE RUN: Publishing $package to $PUBLISH_URL"
               if [ -n "$PUBLISH_URL" ]; then

--- a/packages_to_publish.txt
+++ b/packages_to_publish.txt
@@ -1,0 +1,1 @@
+feluda,operators/image_vec_rep_resnet,operators/cluster_embeddings,operators/vid_vec_rep_clip,operators/dimension_reduction

--- a/packages_to_publish.txt
+++ b/packages_to_publish.txt
@@ -1,1 +1,0 @@
-feluda,operators/image_vec_rep_resnet,operators/cluster_embeddings,operators/vid_vec_rep_clip,operators/dimension_reduction

--- a/scripts/find_updated_packages.py
+++ b/scripts/find_updated_packages.py
@@ -1,18 +1,10 @@
-#!/usr/bin/env python3
-"""
-Script to identify packages with updated versions that need to be published to PyPI.
-This script checks each package's current version against the latest version on PyPI
-and verifies versions against git tags for security.
-"""
-
 import glob
 import os
-import json
-import sys
 import subprocess
+
 import requests
 import tomlkit
-from pathlib import Path
+
 
 def discover_packages(repo_root):
     """
@@ -63,9 +55,11 @@ def discover_packages(repo_root):
                     "path": full_path,
                     "name": package_name,
                     "current_version": current_version,
-                    "tag_format": tag_format
+                    "tag_format": tag_format,
                 }
-                print(f"Discovered package: {package_name} ({current_version}) at {package_root}")
+                print(
+                    f"Discovered package: {package_name} ({current_version}) at {package_root}"
+                )
             else:
                 print(f"Warning: pyproject.toml not found in {package_root}")
         except Exception as e:
@@ -73,11 +67,12 @@ def discover_packages(repo_root):
 
     return packages
 
+
 def get_pypi_version(package_name, test_pypi=True):
     """
     Get the latest version of a package on PyPI.
     Returns None if the package is not found or in case of an error.
-    
+
     Args:
         package_name (str): The name of the package.
         test_pypi (bool, optional): Whether to check Test PyPI instead of production PyPI.
@@ -86,49 +81,59 @@ def get_pypi_version(package_name, test_pypi=True):
         # Use Test PyPI or production PyPI based on the parameter
         base_url = "https://test.pypi.org" if test_pypi else "https://pypi.org"
         response = requests.get(f"{base_url}/pypi/{package_name}/json")
-        
+
         if response.status_code == 200:
             data = response.json()
             return data["info"]["version"]
         elif response.status_code == 404:
-            print(f"Package {package_name} not found on {'Test PyPI' if test_pypi else 'PyPI'} (this might be the first release)")
+            print(
+                f"Package {package_name} not found on {'Test PyPI' if test_pypi else 'PyPI'} (this might be the first release)"
+            )
             return None
         else:
-            print(f"Error fetching {'Test PyPI' if test_pypi else 'PyPI'} version for {package_name}: HTTP {response.status_code}")
+            print(
+                f"Error fetching {'Test PyPI' if test_pypi else 'PyPI'} version for {package_name}: HTTP {response.status_code}"
+            )
             return None
     except Exception as e:
-        print(f"Error checking {'Test PyPI' if test_pypi else 'PyPI'} for {package_name}: {e}")
+        print(
+            f"Error checking {'Test PyPI' if test_pypi else 'PyPI'} for {package_name}: {e}"
+        )
         return None
+
 
 def verify_git_tag_exists(package_name, version, tag_format):
     """
     Verify that a git tag exists for the specified package version.
-    
+
     Args:
         package_name (str): Name of the package.
         version (str): Version to check.
         tag_format (str): Tag format template.
-    
+
     Returns:
         bool: True if the tag exists, False otherwise.
     """
     try:
         # Format the tag according to the tag_format
         tag_name = tag_format.format(name=package_name, version=version)
-        
+
         # Check if the tag exists
         cmd = ["git", "tag", "--list", tag_name]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        
+
         exists = tag_name in result.stdout.splitlines()
         if exists:
             print(f"Found git tag {tag_name} for {package_name} version {version}")
         else:
-            print(f"Warning: No git tag found for {package_name} version {version} (expected tag: {tag_name})")
+            print(
+                f"Warning: No git tag found for {package_name} version {version} (expected tag: {tag_name})"
+            )
         return exists
     except subprocess.CalledProcessError as e:
         print(f"Error checking git tag for {package_name}: {e}")
         return False
+
 
 def main():
     repo_root = os.getcwd()
@@ -138,47 +143,57 @@ def main():
 
     # Determine whether to check Test PyPI or production PyPI
     # If CHECK_TEST_PYPI is set to "true" in environment variables, use Test PyPI
-    check_test_pypi = os.environ.get("CHECK_TEST_PYPI", "true").lower() == "true"
-    
+    check_test_pypi = os.environ.get("CHECK_TEST_PYPI", "false").lower() == "true"
+
     # Force tag verification or not (default to true)
     verify_tags = os.environ.get("VERIFY_TAGS", "true").lower() == "true"
-    
-    print(f"Checking package versions against {'Test PyPI' if check_test_pypi else 'production PyPI'}")
+
+    print(
+        f"Checking package versions against {'Test PyPI' if check_test_pypi else 'production PyPI'}"
+    )
     if verify_tags:
         print("Git tag verification is enabled")
     else:
         print("Warning: Git tag verification is disabled")
-    
+
     for package_root, package_info in packages.items():
         try:
             package_name = package_info["name"]
             current_version = package_info["current_version"]
             tag_format = package_info["tag_format"]
-            
+
             # First verify the git tag exists if verification is enabled
             tag_valid = True
             if verify_tags:
-                tag_valid = verify_git_tag_exists(package_name, current_version, tag_format)
+                tag_valid = verify_git_tag_exists(
+                    package_name, current_version, tag_format
+                )
                 if not tag_valid:
-                    packages_with_tag_issues.append(f"{package_name} (version {current_version})")
-            
+                    packages_with_tag_issues.append(
+                        f"{package_name} (version {current_version})"
+                    )
+
             if not tag_valid and verify_tags:
                 print(f"Skipping {package_name} due to missing git tag")
                 continue
-                
+
             # Get the latest version from PyPI (Test or production)
             pypi_version = get_pypi_version(package_name, test_pypi=check_test_pypi)
-            
+
             if pypi_version is None:
                 # Package not found on PyPI, include it for first-time publishing
                 print(f"Package {package_name} will be published for the first time")
                 packages_to_publish.append(package_root)
             elif current_version != pypi_version:
                 # Version is different, include it for publishing
-                print(f"Package {package_name} needs publishing: Local={current_version}, PyPI={pypi_version}")
+                print(
+                    f"Package {package_name} needs publishing: Local={current_version}, PyPI={pypi_version}"
+                )
                 packages_to_publish.append(package_root)
             else:
-                print(f"Package {package_name} is up to date (version {current_version})")
+                print(
+                    f"Package {package_name} is up to date (version {current_version})"
+                )
         except Exception as e:
             print(f"Error checking version for {package_info['name']}: {e}")
 
@@ -190,12 +205,15 @@ def main():
     if packages_with_tag_issues:
         with open("tag_verification_issues.txt", "w") as f:
             f.write("\n".join(packages_with_tag_issues))
-        print(f"\nWarning: {len(packages_with_tag_issues)} packages have git tag verification issues. See tag_verification_issues.txt")
+        print(
+            f"\nWarning: {len(packages_with_tag_issues)} packages have git tag verification issues. See tag_verification_issues.txt"
+        )
 
     if packages_to_publish:
         print(f"\nPackages to publish: {', '.join(packages_to_publish)}")
     else:
         print("\nNo packages need to be published.")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/find_updated_packages.py
+++ b/scripts/find_updated_packages.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Script to identify packages with updated versions that need to be published to PyPI.
+This script checks each package's current version against the latest version on PyPI.
+"""
+
+import glob
+import os
+import json
+import sys
+import requests
+import tomlkit
+from pathlib import Path
+
+def discover_packages(repo_root):
+    """
+    Discover all packages in the monorepo with their pyproject.toml.
+    """
+    packages = {}
+
+    # Root package (feluda)
+    package_roots = ["feluda"]
+
+    # Discover packages inside 'operators' directory using glob
+    operators_path = os.path.join(repo_root, "operators")
+    if os.path.isdir(operators_path):
+        for folder in glob.glob(f"{operators_path}/*/pyproject.toml"):
+            package_roots.append(os.path.dirname(folder).replace(f"{repo_root}/", ""))
+
+    for package_root in package_roots:
+        try:
+            if package_root == "feluda":
+                pyproject_path = os.path.join(repo_root, "pyproject.toml")
+                full_path = os.path.join(repo_root, "feluda")
+            else:
+                full_path = os.path.join(repo_root, package_root)
+                pyproject_path = os.path.join(full_path, "pyproject.toml")
+
+            if os.path.exists(pyproject_path):
+                with open(pyproject_path, "r") as f:
+                    pyproject_data = tomlkit.parse(f.read())
+
+                # Get package name and version
+                package_name = pyproject_data.get("project", {}).get("name")
+                current_version = pyproject_data.get("project", {}).get("version")
+
+                if not package_name or not current_version:
+                    print(f"Warning: Missing name or version in {pyproject_path}")
+                    continue
+
+                packages[package_root] = {
+                    "path": full_path,
+                    "name": package_name,
+                    "current_version": current_version,
+                }
+                print(f"Discovered package: {package_name} ({current_version}) at {package_root}")
+            else:
+                print(f"Warning: pyproject.toml not found in {package_root}")
+        except Exception as e:
+            print(f"Error discovering package at {package_root}: {e}")
+
+    return packages
+
+def get_pypi_version(package_name, test_pypi=True):
+    """
+    Get the latest version of a package on PyPI.
+    Returns None if the package is not found or in case of an error.
+    
+    Args:
+        package_name (str): The name of the package.
+        test_pypi (bool, optional): Whether to check Test PyPI instead of production PyPI.
+    """
+    try:
+        # Use Test PyPI or production PyPI based on the parameter
+        base_url = "https://test.pypi.org" if test_pypi else "https://pypi.org"
+        response = requests.get(f"{base_url}/pypi/{package_name}/json")
+        
+        if response.status_code == 200:
+            data = response.json()
+            return data["info"]["version"]
+        elif response.status_code == 404:
+            print(f"Package {package_name} not found on {'Test PyPI' if test_pypi else 'PyPI'} (this might be the first release)")
+            return None
+        else:
+            print(f"Error fetching {'Test PyPI' if test_pypi else 'PyPI'} version for {package_name}: HTTP {response.status_code}")
+            return None
+    except Exception as e:
+        print(f"Error checking {'Test PyPI' if test_pypi else 'PyPI'} for {package_name}: {e}")
+        return None
+
+def main():
+    repo_root = os.getcwd()
+    packages = discover_packages(repo_root)
+    packages_to_publish = []
+
+    # Determine whether to check Test PyPI or production PyPI
+    # If CHECK_TEST_PYPI is set to "true" in environment variables, use Test PyPI
+    check_test_pypi = os.environ.get("CHECK_TEST_PYPI", "true").lower() == "true"
+    
+    print(f"Checking package versions against {'Test PyPI' if check_test_pypi else 'production PyPI'}")
+    
+    for package_root, package_info in packages.items():
+        try:
+            package_name = package_info["name"]
+            current_version = package_info["current_version"]
+            
+            # Get the latest version from PyPI (Test or production)
+            pypi_version = get_pypi_version(package_name, test_pypi=check_test_pypi)
+            
+            if pypi_version is None:
+                # Package not found on PyPI, include it for first-time publishing
+                print(f"Package {package_name} will be published for the first time")
+                packages_to_publish.append(package_root)
+            elif current_version != pypi_version:
+                # Version is different, include it for publishing
+                print(f"Package {package_name} needs publishing: Local={current_version}, PyPI={pypi_version}")
+                packages_to_publish.append(package_root)
+            else:
+                print(f"Package {package_name} is up to date (version {current_version})")
+        except Exception as e:
+            print(f"Error checking version for {package_info['name']}: {e}")
+
+    # Write the list of packages to publish to a file
+    with open("packages_to_publish.txt", "w") as f:
+        f.write(",".join(packages_to_publish))
+
+    if packages_to_publish:
+        print(f"\nPackages to publish: {', '.join(packages_to_publish)}")
+    else:
+        print("\nNo packages need to be published.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# PyPI Publishing Workflow

## Summary
Added a new GitHub Action workflow to publish packages to PyPI using `uv publish`. The workflow only publishes packages with updated versions compared to what's currently on PyPI.

## Implementation
- Created a GitHub Action workflow that can be triggered manually
- Added a Python script to detect packages with updated versions
- Implemented special handling for the monorepo structure with different package locations
- Added dry run support for safe testing before actual publishing
- Supports publishing to both Test PyPI and production PyPI

## Changes
- Added `.github/workflows/publish-to-pypi.yml` workflow file
- Added `scripts/find_updated_packages.py` helper script

## How to Use
1. Go to Actions > Publish to PyPI > Run workflow
2. Configure options (dry run, PyPI URL)
3. Packages with updated versions will be published automatically

Requires the `PYPI_TOKEN` secret to be set in repository settings.