### PR TITLE
#575 fix: move detect text in image tesseract operator as python libraray

### DIFF
--- a/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
+++ b/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
@@ -1,6 +1,3 @@
-import os
-
-
 def initialize(param):
     global config_psm
     global config_oem
@@ -12,7 +9,9 @@ def initialize(param):
         global pytesseract
         global requests
         global BytesIO
+        global os
 
+        import os
         from io import BytesIO
 
         import pytesseract
@@ -22,16 +21,18 @@ def initialize(param):
         try:
             pytesseract.get_tesseract_version()
         except pytesseract.TesseractNotFoundError:
-            raise RuntimeError(
-                "Tesseract OCR is not installed or not in PATH. "
-            )
+            raise RuntimeError("Tesseract OCR is not installed or not in PATH.")
 
         required_langs = ["eng", "hin", "tam", "tel"]
         try:
             installed_langs = pytesseract.get_languages()
-            missing_langs = [lang for lang in required_langs if lang not in installed_langs]
+            missing_langs = [
+                lang for lang in required_langs if lang not in installed_langs
+            ]
             if missing_langs:
-                print(f"Warning: Some required language packs are not installed: {', '.join(missing_langs)}")
+                print(
+                    f"Warning: Some required language packs are not installed: {', '.join(missing_langs)}"
+                )
                 print("OCR may not work correctly for these languages.")
         except Exception as e:
             print(f"Warning: Could not verify language pack installation: {e}")
@@ -43,29 +44,24 @@ def initialize(param):
         )
 
 
-def run(image_path, delete_after=False):
-
-
+def run(image_path):
+    data = None
     try:
         with Image.open(image_path) as load_image:
             data = pytesseract.image_to_string(
-                load_image, lang="eng+hin+tam+tel", config=f"--psm {config_psm} --oem {config_oem}"
+                load_image,
+                lang="eng+hin+tam+tel",
+                config=f"--psm {config_psm} --oem {config_oem}",
             )
-
-        if delete_after and os.path.exists(image_path):
-            try:
-                os.remove(image_path)
-                print(f"Successfully deleted temporary file: {image_path}")
-            except OSError as e:
-                print(f"Warning: Could not delete file {image_path}: {e}")
-
         return data
 
     except Exception as e:
-        if delete_after and os.path.exists(image_path):
-            try:
-                os.remove(image_path)
-                print(f"Deleted temporary file after error: {image_path}")
-            except OSError as e:
-                print(f"Warning: Could not delete file {image_path} after error: {e}")
+        print(f"Error during OCR: {e}")
         raise RuntimeError(f"Text detection failed: {e}")
+
+    finally:
+        try:
+            if os.path.exists(image_path):
+                os.remove(image_path)
+        except OSError as e:
+            print(f"Warning: Could not delete file {image_path}: {e}")

--- a/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
+++ b/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
@@ -1,3 +1,6 @@
+import os
+
+
 def initialize(param):
     global config_psm
     global config_oem
@@ -9,6 +12,7 @@ def initialize(param):
         global pytesseract
         global requests
         global BytesIO
+
         from io import BytesIO
 
         import pytesseract
@@ -39,13 +43,29 @@ def initialize(param):
         )
 
 
-def run(image_path):
+def run(image_path, delete_after=False):
+
+
     try:
         with Image.open(image_path) as load_image:
             data = pytesseract.image_to_string(
                 load_image, lang="eng+hin+tam+tel", config=f"--psm {config_psm} --oem {config_oem}"
             )
-        return data
-    except Exception as e:
-        raise RuntimeError(f"Text detection failed: {e}")
 
+        if delete_after and os.path.exists(image_path):
+            try:
+                os.remove(image_path)
+                print(f"Successfully deleted temporary file: {image_path}")
+            except OSError as e:
+                print(f"Warning: Could not delete file {image_path}: {e}")
+
+        return data
+
+    except Exception as e:
+        if delete_after and os.path.exists(image_path):
+            try:
+                os.remove(image_path)
+                print(f"Deleted temporary file after error: {image_path}")
+            except OSError as e:
+                print(f"Warning: Could not delete file {image_path} after error: {e}")
+        raise RuntimeError(f"Text detection failed: {e}")

--- a/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
+++ b/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
@@ -49,16 +49,3 @@ def run(image_path):
     except Exception as e:
         raise RuntimeError(f"Text detection failed: {e}")
 
-def cleanup(param):
-    pass
-
-
-def state():
-    pass
-
-
-# image_url = "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/text-in-image-test-hindi.png"
-# response = requests.get(image_url)
-# response.raise_for_status()
-# text_data = run(BytesIO(response.content))
-# print(text_data)

--- a/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
+++ b/operators/detect_text_in_image_tesseract/detect_text_in_image_tesseract.py
@@ -1,0 +1,64 @@
+def initialize(param):
+    global config_psm
+    global config_oem
+    config_psm = param.get("psm", 6)
+    config_oem = param.get("oem", 1)
+
+    try:
+        global Image
+        global pytesseract
+        global requests
+        global BytesIO
+        from io import BytesIO
+
+        import pytesseract
+        import requests
+        from PIL import Image
+
+        try:
+            pytesseract.get_tesseract_version()
+        except pytesseract.TesseractNotFoundError:
+            raise RuntimeError(
+                "Tesseract OCR is not installed or not in PATH. "
+            )
+
+        required_langs = ["eng", "hin", "tam", "tel"]
+        try:
+            installed_langs = pytesseract.get_languages()
+            missing_langs = [lang for lang in required_langs if lang not in installed_langs]
+            if missing_langs:
+                print(f"Warning: Some required language packs are not installed: {', '.join(missing_langs)}")
+                print("OCR may not work correctly for these languages.")
+        except Exception as e:
+            print(f"Warning: Could not verify language pack installation: {e}")
+
+    except ImportError as e:
+        raise ImportError(
+            f"Failed to import required packages: {e}. "
+            "Please ensure pytesseract and Pillow are installed."
+        )
+
+
+def run(image_path):
+    try:
+        with Image.open(image_path) as load_image:
+            data = pytesseract.image_to_string(
+                load_image, lang="eng+hin+tam+tel", config=f"--psm {config_psm} --oem {config_oem}"
+            )
+        return data
+    except Exception as e:
+        raise RuntimeError(f"Text detection failed: {e}")
+
+def cleanup(param):
+    pass
+
+
+def state():
+    pass
+
+
+# image_url = "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/text-in-image-test-hindi.png"
+# response = requests.get(image_url)
+# response.raise_for_status()
+# text_data = run(BytesIO(response.content))
+# print(text_data)

--- a/operators/detect_text_in_image_tesseract/pyproject.toml
+++ b/operators/detect_text_in_image_tesseract/pyproject.toml
@@ -2,9 +2,7 @@
 name = "feluda-detect-text-in-image-tesseract"
 version = "0.0.0"
 requires-python = ">=3.10"
-dependencies = [ "pytesseract>=0.3.10",
-    "Pillow>=11.1.0",
-    "requests>=2.28.0",]
+dependencies = ["pytesseract>=0.3.10", "Pillow>=11.1.0", "requests>=2.28.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/operators/detect_text_in_image_tesseract/pyproject.toml
+++ b/operators/detect_text_in_image_tesseract/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "feluda-detect-text-in-image-tesseract"
+version = "0.1.3"
+requires-python = ">=3.10"
+dependencies = [ "pytesseract>=0.3.10",
+    "Pillow>=11.1.0",
+    "requests>=2.28.0",]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.semantic_release]
+version_variable = ["pyproject.toml:project.version"]
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
+tag_format = "{name}-{version}"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/operators/detect_text_in_image_tesseract/pyproject.toml
+++ b/operators/detect_text_in_image_tesseract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "feluda-detect-text-in-image-tesseract"
-version = "0.1.3"
+version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = [ "pytesseract>=0.3.10",
     "Pillow>=11.1.0",

--- a/operators/detect_text_in_image_tesseract/test.py
+++ b/operators/detect_text_in_image_tesseract/test.py
@@ -25,14 +25,18 @@ class Test(unittest.TestCase):
         self.assertEqual(image_text.strip(), expected_text.strip())
 
     def test_sample_image_from_disk_tamil(self):
-        image_path = r"src/core/operators/sample_data/tamil-text.png"
-        image_text = detect_text_in_image_tesseract.run(image_path)
+        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/tamil-text.png"
+        image_obj = ImageFactory.make_from_url_to_path(image_url)
+        image_path = image_obj["path"]
+        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
         cleaned_image_text = re.sub(r'[\u200c\u200b]', '', image_text)
         expected_text = "காதல் மற்றும் போர்"
         self.assertEqual(cleaned_image_text.strip(), expected_text.strip())
 
     def test_sample_image_from_disk_telugu(self):
-        image_path = r"src/core/operators/sample_data/telugu-text.png"
-        image_text = detect_text_in_image_tesseract.run(image_path)
+        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/telugu-text.png"
+        image_obj = ImageFactory.make_from_url_to_path(image_url)
+        image_path = image_obj["path"]
+        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
         expected_text = "నేను భూమిని ప్రేమిస్తున్నాను"
         self.assertEqual(image_text.strip(), expected_text.strip())

--- a/operators/detect_text_in_image_tesseract/test.py
+++ b/operators/detect_text_in_image_tesseract/test.py
@@ -17,26 +17,26 @@ class Test(unittest.TestCase):
         pass
 
     def test_sample_image_from_disk_hindi(self):
-        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/hindi-text-2.png"
+        image_url = "https://github.com/tattle-made/feluda_datasets/raw/main/feluda-sample-media/hindi-text-2.png"
         image_obj = ImageFactory.make_from_url_to_path(image_url)
         image_path = image_obj["path"]
-        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
+        image_text = detect_text_in_image_tesseract.run(image_path)
         expected_text = "( मेरे पीछे कौन आ रहा है)"
         self.assertEqual(image_text.strip(), expected_text.strip())
 
     def test_sample_image_from_disk_tamil(self):
-        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/tamil-text.png"
+        image_url = "https://github.com/tattle-made/feluda_datasets/raw/main/feluda-sample-media/tamil-text.png"
         image_obj = ImageFactory.make_from_url_to_path(image_url)
         image_path = image_obj["path"]
-        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
-        cleaned_image_text = re.sub(r'[\u200c\u200b]', '', image_text)
+        image_text = detect_text_in_image_tesseract.run(image_path)
+        cleaned_image_text = re.sub(r"[\u200c\u200b]", "", image_text)
         expected_text = "காதல் மற்றும் போர்"
         self.assertEqual(cleaned_image_text.strip(), expected_text.strip())
 
     def test_sample_image_from_disk_telugu(self):
-        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/telugu-text.png"
+        image_url = "https://github.com/tattle-made/feluda_datasets/raw/main/feluda-sample-media/telugu-text.png"
         image_obj = ImageFactory.make_from_url_to_path(image_url)
         image_path = image_obj["path"]
-        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
+        image_text = detect_text_in_image_tesseract.run(image_path)
         expected_text = "నేను భూమిని ప్రేమిస్తున్నాను"
         self.assertEqual(image_text.strip(), expected_text.strip())

--- a/operators/detect_text_in_image_tesseract/test.py
+++ b/operators/detect_text_in_image_tesseract/test.py
@@ -1,6 +1,7 @@
 import re
 import unittest
 
+from feluda.models.media_factory import ImageFactory
 from operators.detect_text_in_image_tesseract import detect_text_in_image_tesseract
 
 
@@ -16,8 +17,10 @@ class Test(unittest.TestCase):
         pass
 
     def test_sample_image_from_disk_hindi(self):
-        image_path =  r"src/core/operators/sample_data/hindi-text-2.png"
-        image_text = detect_text_in_image_tesseract.run(image_path)
+        image_url = "https://raw.githubusercontent.com/tattle-made/feluda_datasets/main/feluda-sample-media/hindi-text-2.png"
+        image_obj = ImageFactory.make_from_url_to_path(image_url)
+        image_path = image_obj["path"]
+        image_text = detect_text_in_image_tesseract.run(image_path, delete_after=True)
         expected_text = "( मेरे पीछे कौन आ रहा है)"
         self.assertEqual(image_text.strip(), expected_text.strip())
 
@@ -33,7 +36,3 @@ class Test(unittest.TestCase):
         image_text = detect_text_in_image_tesseract.run(image_path)
         expected_text = "నేను భూమిని ప్రేమిస్తున్నాను"
         self.assertEqual(image_text.strip(), expected_text.strip())
-
-
-# if __name__ == "__main__":
-#     unittest.main()

--- a/operators/detect_text_in_image_tesseract/test.py
+++ b/operators/detect_text_in_image_tesseract/test.py
@@ -1,0 +1,39 @@
+import re
+import unittest
+
+from operators.detect_text_in_image_tesseract import detect_text_in_image_tesseract
+
+
+class Test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # initialize operator
+        detect_text_in_image_tesseract.initialize(param={})
+
+    @classmethod
+    def tearDownClass(cls):
+        # delete config files
+        pass
+
+    def test_sample_image_from_disk_hindi(self):
+        image_path =  r"src/core/operators/sample_data/hindi-text-2.png"
+        image_text = detect_text_in_image_tesseract.run(image_path)
+        expected_text = "( मेरे पीछे कौन आ रहा है)"
+        self.assertEqual(image_text.strip(), expected_text.strip())
+
+    def test_sample_image_from_disk_tamil(self):
+        image_path = r"src/core/operators/sample_data/tamil-text.png"
+        image_text = detect_text_in_image_tesseract.run(image_path)
+        cleaned_image_text = re.sub(r'[\u200c\u200b]', '', image_text)
+        expected_text = "காதல் மற்றும் போர்"
+        self.assertEqual(cleaned_image_text.strip(), expected_text.strip())
+
+    def test_sample_image_from_disk_telugu(self):
+        image_path = r"src/core/operators/sample_data/telugu-text.png"
+        image_text = detect_text_in_image_tesseract.run(image_path)
+        expected_text = "నేను భూమిని ప్రేమిస్తున్నాను"
+        self.assertEqual(image_text.strip(), expected_text.strip())
+
+
+# if __name__ == "__main__":
+#     unittest.main()


### PR DESCRIPTION
Raised PR under - Move detect text in image tesseract operator as python library https://github.com/tattle-made/feluda/issues/575
Overview:
Hey @aatmanvaidya,
Changes Made:
Updated dependencies in pyproject.toml with appropriate version constraints
Documented system requirements for installing the Tesseract OCR engine
Clarified the need for language packs (eng, hin, tam, tel) to support multi-language text detection