### PR TITLE
refactor: `vid_vec_rep_clip` Operator

### DIFF
--- a/operators/vid_vec_rep_clip/test.py
+++ b/operators/vid_vec_rep_clip/test.py
@@ -1,35 +1,29 @@
-import unittest
-from unittest.case import skip
+import pytest
 
 from feluda.models.media_factory import VideoFactory
 from operators.vid_vec_rep_clip import vid_vec_rep_clip
 
 
-class Test(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # initialize operator
-        param = {}
-        vid_vec_rep_clip.initialize(param)
+@pytest.fixture(scope="module", autouse=True)
+def initialize_operator():
+    vid_vec_rep_clip.initialize()
 
-    @classmethod
-    def tearDownClass(cls):
-        # delete config files
-        pass
 
-    @skip
-    def test_sample_video_from_disk(self):
-        video_path = VideoFactory.make_from_file_on_disk(
-            r"core/operators/sample_data/sample-cat-video.mp4"
-        )
-        result = vid_vec_rep_clip.run(video_path)
-        for vec in result:
-            self.assertEqual(len(vec.get("vid_vec")), 512)
+def test_sample_video_from_url():
+    video_url = (
+        "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/cat_vid_2mb.mp4"
+    )
+    file = VideoFactory.make_from_url(video_url)
+    result = vid_vec_rep_clip.run(file)
+    for vec in result:
+        assert len(vec.get("vid_vec")) == 512
 
-    # @skip
-    def test_sample_video_from_url(self):
-        video_url = "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/cat_vid_2mb.mp4"
-        video_path = VideoFactory.make_from_url(video_url)
-        result = vid_vec_rep_clip.run(video_path)
-        for vec in result:
-            self.assertEqual(len(vec.get("vid_vec")), 512)
+
+@pytest.mark.skip(reason="This test requires a local video file.")
+def test_sample_video_from_disk():
+    file = VideoFactory.make_from_file_on_disk(
+        "core/operators/sample_data/sample-cat-video.mp4"
+    )
+    result = vid_vec_rep_clip.run(file)
+    for vec in result:
+        assert len(vec.get("vid_vec")) == 512


### PR DESCRIPTION
Done - 
1. Type Hints
2. Docstrings
2. Unittest to Pytest

Currently working on ffmpeg standardization and new tests.  

A few points - 
1. The parameter `fname` was being passed both at class instantiation and function calls. This is not the standard way. It has to be passed either 
 - at class instantiation and then stored as a class variable
 - or functions are kept modular and parameters are passed
 2. The only `cleanup` methods i can think of is `gc.collect()` and `torch.cuda.empty_cache`. We cannot explicitly delete variables because they are in the scope of `initialize` / `run` function.
 3. For the same reason as `Point 2`, we cannot return the `vid_analyzer` object, 'model` or `frames`, because again, they are not in global memory. This can be tried to solve by initializing global variables, then assigning values to them in the functions. Then these can be accessed and returned in the state. Something like this - 
![image](https://github.com/user-attachments/assets/5daa7424-5bd4-49b2-8b40-19c3bf37a4dd)
4. The private class inside a function is hard to look at, but again it depends on a lot of local variables. This could be solved by global variables like mentioned in `Point 3`. 
5. This operator is almost a single class, except for the functions `gendata`, and the 4 other main methods. `gendata` can just be made a method of the `VideoAnalyzer` class to make it seamless. 
6. Points 2-5 brought me back to the original thought of just making operators as classes, would solve a lot of things. But one major issue is the BaseOperator. It cannot be imported into all operators at runtime, and we cannot include it in all the packages. One solution to this is - 
```python
try:
    from base import BaseClass
except ImportError:
    BaseClass = object 

class NewClass(BaseClass):
    def __init__(self):
        super().__init__()
``` 
This allows us to import/validate it at development and ignore it at runtime. Another solution is having all the operators have a dependancy on Feluda main package (this could lead on to inter-operable utilities or maybe unified loggers,etc for all the operators)
I know we've discussed a lot about classes, just something i discovered. The newer operators like `dimension_reduction` and `image_vec_rep_resnet` already have public classes, so something to think about in the long run.

I think this discussion will make work on next operators much easier 