### PR TITLE
refactor: `vid_vec_rep_clip` operator

### DIFF
--- a/feluda/__init__.py
+++ b/feluda/__init__.py
@@ -1,3 +1,4 @@
+from .base_operator import BaseOperator
 from .feluda import Feluda
 
-__all__ = ["Feluda"]
+__all__ = ["BaseOperator", "Feluda"]

--- a/operators/vid_vec_rep_clip/README.md
+++ b/operators/vid_vec_rep_clip/README.md
@@ -1,0 +1,46 @@
+# VidVecRepClip Operator
+
+## Description
+
+The `VidVecRepClip` operator extracts vector representations from videos using the CLIP-ViT-B-32 model. It works by extracting I-frames (keyframes) from a video file using FFmpeg, then generating a 512-dimensional feature vector for each frame using the CLIP model. The operator yields both the average vector for the video and vectors for each I-frame.
+
+## Model Information
+
+- **Model**: [CLIP ViT-B/32](https://huggingface.co/openai/clip-vit-base-patch32)
+- **Source**: OpenAI, via HuggingFace Transformers
+- **Vector Size**: 512
+- **Usage**: The model is used to generate embeddings for video frames, enabling downstream tasks such as video similarity, clustering, and zero-shot classification.
+
+## System Dependencies
+
+- Python >= 3.10
+- FFmpeg
+  - On Windows, you have two methods -
+      1. Download from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH.
+      2. Use `winget install ffmpeg` from an elevated powershell. (Make sure you have winget installed first)
+  - On Linux/macOS, install via your package manager (e.g., `sudo apt install ffmpeg`).
+
+## Operator Dependencies
+
+- PyTorch >= 2.6.0
+- Torchvision >= 0.21.0
+- Transformers >= 4.51.1
+- Pillow >= 11.1.0
+
+## How to Run the Tests
+
+1. Install dependencies (in your virtual environment):
+
+   ```bash
+   pip install -r ../../pyproject.toml
+   pip install "feluda[dev]"
+   ```
+
+2. Ensure FFmpeg is installed and available in your PATH.
+3. Run the tests:
+
+   ```bash
+   pytest test.py
+   ```
+
+4. For local video tests, place a sample video at the specified path or update the test accordingly.

--- a/operators/vid_vec_rep_clip/README.md
+++ b/operators/vid_vec_rep_clip/README.md
@@ -30,10 +30,11 @@ The `VidVecRepClip` operator extracts vector representations from videos using t
 ## How to Run the Tests
 
 1. Install dependencies (in your virtual environment):
+   Ensure that you are in the root directory of the **operator** (where `pyproject.toml` is located.)
 
    ```bash
-   pip install -r ../../pyproject.toml
-   pip install "feluda[dev]"
+   uv pip install "."
+   uv pip install "feluda[dev]"
    ```
 
 2. Ensure FFmpeg is installed and available in your PATH.

--- a/operators/vid_vec_rep_clip/README.md
+++ b/operators/vid_vec_rep_clip/README.md
@@ -29,19 +29,19 @@ The `VidVecRepClip` operator extracts vector representations from videos using t
 
 ## How to Run the Tests
 
-1. Install dependencies (in your virtual environment):
-   Ensure that you are in the root directory of the **operator** (where `pyproject.toml` is located.)
+1. Ensure that you are in the root directory of the `feluda` project.
+2. Install dependencies (in your virtual environment):
 
    ```bash
-   uv pip install "."
+   uv pip install "./operators/vid_vec_rep_clip"
    uv pip install "feluda[dev]"
    ```
 
-2. Ensure FFmpeg is installed and available in your PATH.
-3. Run the tests:
+3. Ensure FFmpeg is installed and available in your PATH.
+4. Run the tests:
 
    ```bash
-   pytest test.py
+   pytest operators/vid_vec_rep_clip/test.py
    ```
 
-4. For local video tests, place a sample video at the specified path or update the test accordingly.
+5. For local video tests, place a sample video at the specified path or update the test accordingly.

--- a/operators/vid_vec_rep_clip/__init__.py
+++ b/operators/vid_vec_rep_clip/__init__.py
@@ -1,3 +1,3 @@
-from vid_vec_rep_clip import VidVecRepClip
+from .vid_vec_rep_clip import VidVecRepClip
 
 __all__ = ["VidVecRepClip"]

--- a/operators/vid_vec_rep_clip/__init__.py
+++ b/operators/vid_vec_rep_clip/__init__.py
@@ -1,0 +1,3 @@
+from vid_vec_rep_clip import VidVecRepClip
+
+__all__ = ["VidVecRepClip"]

--- a/operators/vid_vec_rep_clip/pyproject.toml
+++ b/operators/vid_vec_rep_clip/pyproject.toml
@@ -3,6 +3,7 @@ name = "feluda-vid-vec-rep-clip"
 version = "0.1.4"
 requires-python = ">=3.10"
 dependencies = [
+    "feluda",
     "torch>=2.6.0",
     "torchvision>=0.21.0",
     "transformers>=4.51.1",

--- a/operators/vid_vec_rep_clip/pyproject.toml
+++ b/operators/vid_vec_rep_clip/pyproject.toml
@@ -3,7 +3,7 @@ name = "feluda-vid-vec-rep-clip"
 version = "0.1.4"
 requires-python = ">=3.10"
 dependencies = [
-    "feluda",
+    "feluda[video]",
     "torch>=2.6.0",
     "torchvision>=0.21.0",
     "transformers>=4.51.1",

--- a/operators/vid_vec_rep_clip/test.py
+++ b/operators/vid_vec_rep_clip/test.py
@@ -1,5 +1,3 @@
-from unittest import patch
-
 import pytest
 
 from feluda.factory.media_factory import VideoFactory
@@ -33,9 +31,8 @@ def test_sample_video_from_disk(operator: VidVecRepClip):
 
 
 def test_initialization_ffmpeg_not_found():
-    with patch("shutil.which", return_value=None):
-        with pytest.raises(RuntimeError, match="FFmpeg is not installed"):
-            VidVecRepClip()
+    with pytest.raises(RuntimeError, match="FFmpeg is not installed"):
+        VidVecRepClip()
 
 
 def test_run_invalid_file_object(operator: VidVecRepClip):

--- a/operators/vid_vec_rep_clip/test.py
+++ b/operators/vid_vec_rep_clip/test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from feluda.factory.media_factory import VideoFactory
+from feluda.factory import VideoFactory
 from operators.vid_vec_rep_clip import VidVecRepClip
 
 
@@ -30,7 +30,8 @@ def test_sample_video_from_disk(operator: VidVecRepClip):
         assert len(vec.get("vid_vec")) == 512
 
 
-def test_initialization_ffmpeg_not_found():
+def test_initialization_ffmpeg_not_found(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
     with pytest.raises(RuntimeError, match="FFmpeg is not installed"):
         VidVecRepClip()
 

--- a/operators/vid_vec_rep_clip/test.py
+++ b/operators/vid_vec_rep_clip/test.py
@@ -1,35 +1,48 @@
-import unittest
-from unittest.case import skip
+from unittest import patch
 
-from feluda.factory import VideoFactory
-from operators.vid_vec_rep_clip import vid_vec_rep_clip
+import pytest
+
+from feluda.factory.media_factory import VideoFactory
+from operators.vid_vec_rep_clip import VidVecRepClip
 
 
-class Test(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # initialize operator
-        param = {}
-        vid_vec_rep_clip.initialize(param)
+@pytest.fixture(scope="module")
+def operator():
+    operator = VidVecRepClip()
+    return operator
 
-    @classmethod
-    def tearDownClass(cls):
-        # delete config files
-        pass
 
-    @skip
-    def test_sample_video_from_disk(self):
-        video_path = VideoFactory.make_from_file_on_disk(
-            r"core/operators/sample_data/sample-cat-video.mp4"
-        )
-        result = vid_vec_rep_clip.run(video_path)
-        for vec in result:
-            self.assertEqual(len(vec.get("vid_vec")), 512)
+def test_sample_video_from_url(operator: VidVecRepClip):
+    video_url = (
+        "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/cat_vid_2mb.mp4"
+    )
+    file = VideoFactory.make_from_url(video_url)
+    result = operator.run(file)
+    for vec in result:
+        assert len(vec.get("vid_vec")) == 512
 
-    # @skip
-    def test_sample_video_from_url(self):
-        video_url = "https://tattle-media.s3.amazonaws.com/test-data/tattle-search/cat_vid_2mb.mp4"
-        video_path = VideoFactory.make_from_url(video_url)
-        result = vid_vec_rep_clip.run(video_path)
-        for vec in result:
-            self.assertEqual(len(vec.get("vid_vec")), 512)
+
+@pytest.mark.skip(reason="This test requires a local video file.")
+def test_sample_video_from_disk(operator: VidVecRepClip):
+    file = VideoFactory.make_from_file_on_disk(
+        "core/operators/sample_data/sample-cat-video.mp4"
+    )
+    result = operator.run(file)
+    for vec in result:
+        assert len(vec.get("vid_vec")) == 512
+
+
+def test_initialization_ffmpeg_not_found():
+    with patch("shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="FFmpeg is not installed"):
+            VidVecRepClip()
+
+
+def test_run_invalid_file_object(operator: VidVecRepClip):
+    with pytest.raises(ValueError, match="Invalid file object"):
+        operator.run("not_a_dict")
+
+
+def test_run_file_not_found(operator: VidVecRepClip):
+    with pytest.raises(FileNotFoundError):
+        operator.run({"path": "fake.mp4"})

--- a/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
+++ b/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from typing import Generator
+from typing import Generator, Optional
 
 import torch
 from PIL import Image
@@ -165,7 +165,7 @@ class VidVecRepClip(BaseOperator):
             }
 
     def run(
-        self, file: VideoFactory, remove_after_processing: bool = False
+        self, file: VideoFactory, remove_after_processing: Optional[bool] = False
     ) -> Generator[dict, None, None]:
         """Run the operator.
 

--- a/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
+++ b/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
@@ -165,7 +165,7 @@ class VidVecRepClip(BaseOperator):
             }
 
     def run(
-        self, file: VideoFactory, remove_after_processing: bool = True
+        self, file: VideoFactory, remove_after_processing: bool = False
     ) -> Generator[dict, None, None]:
         """Run the operator.
 

--- a/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
+++ b/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
@@ -18,11 +18,12 @@ class VidVecRepClip(BaseOperator):
     """Operator to extract video vector representations using CLIP-ViT-B-32."""
 
     def __init__(self) -> None:
-        """Initialize the `VideoAnalyzer` class."""
+        """Initialize the `VidVecRepClip` class."""
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.frame_images = []
         self.feature_matrix = []
         self.load_model()
+        self.validate_system()
 
     def load_model(self) -> None:
         """Load the CLIP model and processor onto the specified device."""
@@ -142,10 +143,7 @@ class VidVecRepClip(BaseOperator):
             return features
 
     def gendata(self) -> Generator[dict, None, None]:
-        """Yield video vector representations from the `VideoAnalyzer` prototype.
-
-        Args:
-            vid_analyzer (VideoAnalyzer): `VideoAnalyzer` instance
+        """Yield video vector representations from the `VidVecRepClip` prototype.
 
         Yields:
             dict: A dictionary containing:

--- a/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
+++ b/operators/vid_vec_rep_clip/vid_vec_rep_clip.py
@@ -1,39 +1,148 @@
-"""
-Operator to extract video vector representations using CLIP-ViT-B-32.
-"""
+import contextlib
+import gc
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Generator
+
+import torch
+from PIL import Image
+from transformers import AutoProcessor, CLIPModel
+
+from feluda import BaseOperator
+from feluda.factory import VideoFactory
 
 
-def initialize(param):
-    """
-    Initializes the operator.
+class VidVecRepClip(BaseOperator):
+    """Operator to extract video vector representations using CLIP-ViT-B-32."""
 
-    Args:
-        param (dict): Parameters for initialization
-    """
-    print("Installing packages for vid_vec_rep_clip")
-    global os
-    global VideoAnalyzer, gendata
+    def __init__(self) -> None:
+        """Initialize the `VideoAnalyzer` class."""
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.frame_images = []
+        self.feature_matrix = []
+        self.load_model()
 
-    # Imports
-    import os
-    import subprocess
-    import tempfile
+    def load_model(self) -> None:
+        """Load the CLIP model and processor onto the specified device."""
+        try:
+            self.processor = AutoProcessor.from_pretrained(
+                "openai/clip-vit-base-patch32"
+            )
+            self.model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load the CLIP model or processor: {e!s} "
+            ) from e
+        self.model.to(self.device)
 
-    import torch
-    from PIL import Image
-    from transformers import AutoProcessor, CLIPModel
+    @staticmethod
+    def validate_system() -> None:
+        """Validate that required system dependencies are available.
 
-    # Load the model and processor
-    processor = AutoProcessor.from_pretrained("openai/clip-vit-base-patch32")
-    model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
-
-    # Set the device
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.to(device)
-
-    def gendata(vid_analyzer):
+        Checks if FFmpeg is installed and accessible in the system PATH.
         """
-        Yields video vector representations from a `VideoAnalyzer` prototype.
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError(
+                "FFmpeg is not installed or not found in system PATH. "
+                "Please install FFmpeg to use this operator."
+            )
+
+    def get_mean_feature(self) -> torch.Tensor:
+        """Compute the mean feature vector from the feature matrix.
+
+        Returns:
+            torch.Tensor: Mean feature vector
+        """
+        if self.feature_matrix is None or len(self.feature_matrix) == 0:
+            raise ValueError("Feature matrix is empty. Please analyze a video first.")
+        return torch.mean(self.feature_matrix, dim=0)
+
+    def analyze(self, fname: str) -> None:
+        """Analyze the video file and extract features.
+
+        Args:
+            fname (str): Path to the video file
+        """
+        self.frame_images = self.extract_frames(fname)
+
+        if not self.frame_images:
+            raise ValueError(f"No frames could be extracted from: {fname!s}")
+        self.feature_matrix = self.extract_features(self.frame_images)
+
+    @staticmethod
+    def extract_frames(fname: str) -> list[Image.Image]:
+        """Extract I-frames from the video file using `ffmpeg`.
+
+        Args:
+            fname (str): Path to the video file
+
+        Returns:
+            list: List of PIL Images
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Command to extract I-frames using ffmpeg
+            cmd = [
+                "ffmpeg",
+                "-i",
+                fname,
+                "-vf",
+                "select=eq(pict_type\\,I)",
+                "-vsync",
+                "vfr",
+                "-y",
+                os.path.join(temp_dir, "frame_%05d.jpg"),
+            ]
+
+            try:
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=300,  # 5 minute timeout
+                )
+                # print("FFmpeg stdout:", result.stdout)
+                # print("FFmpeg stderr:", result.stderr)
+            except subprocess.TimeoutExpired:
+                raise TimeoutError(f"FFmpeg timed out while processing: {fname}")
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    f"FFmpeg failed to extract frames from {fname}: {e.stderr}"
+                    f"Stdout: {e.stdout}\n"
+                    f"Stderr: {e.stderr}"
+                ) from e
+
+            frames = []
+            for filename in os.listdir(temp_dir):
+                if filename.endswith(".jpg"):
+                    image_path = os.path.join(temp_dir, filename)
+                    with Image.open(image_path) as img:
+                        frames.append(img.copy())
+            return frames
+
+    def extract_features(self, images: list) -> torch.Tensor:
+        """Extract features from a list of images using pre-trained CLIP-ViT-B-32.
+
+        Args:
+            images (list): List of PIL Images
+
+        Returns:
+            torch.Tensor: Feature matrix of shape (batch, 512)
+        """
+        if not images:
+            raise ValueError("Images list cannot be empty")
+        inputs = self.processor(
+            images=images, return_tensors="pt", padding=True, truncation=True
+        )
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}  # move to device
+        with torch.no_grad():
+            features = self.model.get_image_features(**inputs)
+            return features
+
+    def gendata(self) -> Generator[dict, None, None]:
+        """Yield video vector representations from the `VideoAnalyzer` prototype.
 
         Args:
             vid_analyzer (VideoAnalyzer): `VideoAnalyzer` instance
@@ -43,128 +152,71 @@ def initialize(param):
                 - `vid_vec` (list): Vector representation
                 - `is_avg` (bool): A flag indicating whether the vector is the average vector or a I-frame vector
         """
+        if self.feature_matrix is None or len(self.feature_matrix) == 0:
+            raise ValueError("Feature matrix is empty. Please analyze a video first.")
         # average vector
         yield {
-            "vid_vec": vid_analyzer.get_mean_feature().tolist(),
+            "vid_vec": self.get_mean_feature().tolist(),
             "is_avg": True,
         }
         # I-frame vectors
-        for keyframe in vid_analyzer.feature_matrix:
+        for keyframe in self.feature_matrix:
             yield {
                 "vid_vec": keyframe.tolist(),
                 "is_avg": False,
             }
 
-    class VideoAnalyzer:
+    def run(
+        self, file: VideoFactory, remove_after_processing: bool = True
+    ) -> Generator[dict, None, None]:
+        """Run the operator.
+
+        Args:
+            file (dict): `VideoFactory` file object
+            remove_after_processing (bool): Whether to remove the file after processing
+
+        Returns:
+            generator: Yields video and I-frame vector representations
         """
-        A class for video feature extraction.
-        """
-
-        def __init__(self, fname):
-            """
-            Constructor for the `VideoAnalyzer` class.
-
-            Args:
-                fname (str): Path to the video file
-            """
-            self.model = model
-            self.device = device
-            self.frame_images = []
-            self.feature_matrix = []
-            self.analyze(fname)
-
-        def get_mean_feature(self):
-            """
-            Returns:
-                torch.Tensor: Mean feature vector
-            """
-            return torch.mean(self.feature_matrix, dim=0)
-
-        def analyze(self, fname):
-            """
-            Analyzes the video file and extracts features.
-
-            Args:
-                fname (str): Path to the video file
-
-            Raises:
-                FileNotFoundError: If the file is not found
-            """
-            # check if file exists
-            if not os.path.exists(fname):
-                raise FileNotFoundError(f"File not found: {fname}")
-
-            # Extract I-frames and features
-            self.frame_images = self.extract_frames(fname)
-            self.feature_matrix = self.extract_features(self.frame_images)
-
-        def extract_frames(self, fname):
-            """
-            Extracts I-frames from the video file using `ffmpeg`.
-
-            Args:
-                fname (str): Path to the video file
-
-            Returns:
-                list: List of PIL Images
-            """
-            with tempfile.TemporaryDirectory() as temp_dir:
-                # Command to extract I-frames using ffmpeg's command line tool
-                cmd = f"""
-                ffmpeg -i "{fname}" -vf "select=eq(pict_type\,I)" -vsync vfr "{temp_dir}/frame_%05d.jpg"
-                """
-                with subprocess.Popen(
-                    cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-                ) as process:
-                    process.wait()
-                frames = []
-                for filename in os.listdir(temp_dir):
-                    if filename.endswith((".jpg")):
-                        image_path = os.path.join(temp_dir, filename)
-                        with Image.open(image_path) as img:
-                            frames.append(img.copy())
-                return frames
-
-        def extract_features(self, images):
-            """
-            Extracts features from a list of images using pre-trained CLIP-ViT-B-32.
-
-            Args:
-                images (list): List of PIL Images
-
-            Returns:
-                torch.Tensor: Feature matrix of shape (batch, 512)
-            """
-            inputs = processor(
-                images=images, return_tensors="pt", padding=True, truncation=True
+        if not isinstance(file, dict) or "path" not in file:
+            raise ValueError(
+                "Invalid file object. Expected VideoFactory object with 'path' key."
             )
-            inputs = {k: v.to(self.device) for k, v in inputs.items()}  # move to device
-            with torch.no_grad():
-                features = self.model.get_image_features(**inputs)
-                return features
+        fname = file["path"]
 
+        if not os.path.exists(fname):
+            raise FileNotFoundError(f"File not found: {fname}")
 
-def run(file):
-    """
-    Runs the operator.
+        try:
+            self.analyze(fname)
+            return self.gendata()
+        finally:
+            if remove_after_processing:
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(fname)
 
-    Args:
-        file (dict): `VideoFactory` file object
+    def cleanup(self) -> None:
+        """Cleanup the operator."""
+        del self.model
+        del self.processor
 
-    Returns:
-        generator: Yields video and I-frame vector representations
-    """
-    fname = file["path"]
-    try:
-        vid_analyzer = VideoAnalyzer(fname)
-        return gendata(vid_analyzer)
-    finally:
-        os.remove(fname)
+        self.frame_images.clear()
+        self.feature_matrix.clear()
 
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
-def cleanup(param):
-    pass
+    def state(self) -> dict:
+        """Get the state of the operator.
 
-
-def state():
-    pass
+        Returns:
+            dict: State of the operator
+        """
+        return {
+            "device": self.device,
+            "model": self.model,
+            "processor": self.processor,
+            "frame_images": self.frame_images.copy(),
+            "feature_matrix": self.feature_matrix.copy() if self.feature_matrix else [],
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ members = [
     "operators/video_hash_tmk",
 ]
 
+[tool.uv.sources]
+feluda = { workspace = true }
+
 [tool.ruff]
 target-version = "py310"
 line-length = 88


### PR DESCRIPTION
This PR refactors the `VidVecRepClip` operator.

### Key Changes
1. Operator supports the new API, added docstrings and type-hints as well
2. Windows Compatibility for FFmpeg
3. checking if ffmpeg is installed
4. Improved error messages for ffmpeg failures, including stdout/stderr in exceptions for easier debugging.
5. Added new tests
6. Added `README.md`:
