### PR TITLE
GitHub Action to Publish Docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,40 @@
+name: Publish Feluda Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed to push to gh-pages branch
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensures full git history for deployment
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build HTML docs
+        run: |
+          make -C docs clean html  # cleans old build files, then builds fresh HTML
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          publish_branch: gh-pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -2,21 +2,20 @@ name: Publish Feluda Docs
 
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed to push to gh-pages branch
+      contents: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Ensures full git history for deployment
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
@@ -30,7 +29,7 @@ jobs:
 
       - name: Build HTML docs
         run: |
-          make -C docs clean html  # cleans old build files, then builds fresh HTML
+          make -C docs clean html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -2,7 +2,9 @@ name: Publish Feluda Docs
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - development
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
@aatmanvaidya  this workflow should be triggered on commits to `main` branch only right?

Setting up the documentation and `/feluda` route has to be done in the repository settings by the maintainers.   
Resolves issue #649

cc @dennyabrain 