### PR TITLE
fix:  test imports

### DIFF
--- a/operators/classify_video_zero_shot/test.py
+++ b/operators/classify_video_zero_shot/test.py
@@ -1,7 +1,8 @@
 import pytest
 
 from feluda.factory import VideoFactory
-from operators.classify_video_zero_shot import VideoClassifier
+
+from .classify_video_zero_shot import VideoClassifier
 
 
 @pytest.fixture(scope="module")

--- a/operators/cluster_embeddings/test.py
+++ b/operators/cluster_embeddings/test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from operators.cluster_embeddings import ClusterEmbeddings
+from .cluster_embeddings import ClusterEmbeddings
 
 MOCK_DATA = [
     {"payload": "A", "embedding": [0, 1]},

--- a/operators/detect_lewd_images/test.py
+++ b/operators/detect_lewd_images/test.py
@@ -1,7 +1,8 @@
 import pytest
 
 from feluda.factory import ImageFactory
-from operators.detect_lewd_images import LewdImageDetector
+
+from .detect_lewd_images import LewdImageDetector
 
 
 @pytest.fixture(scope="module")

--- a/operators/detect_text_in_image_tesseract/test.py
+++ b/operators/detect_text_in_image_tesseract/test.py
@@ -3,7 +3,8 @@ import re
 import pytest
 
 from feluda.factory import ImageFactory
-from operators.detect_text_in_image_tesseract import ImageTextDetector
+
+from .detect_text_in_image_tesseract import ImageTextDetector
 
 
 @pytest.fixture(scope="module")

--- a/operators/dimension_reduction/test.py
+++ b/operators/dimension_reduction/test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from operators.dimension_reduction.dimension_reduction import (
+from .dimension_reduction import (
     DimensionReduction,
     ReductionModel,
     TSNEReduction,

--- a/operators/image_vec_rep_resnet/test.py
+++ b/operators/image_vec_rep_resnet/test.py
@@ -5,7 +5,8 @@ import pytest
 from PIL import Image
 
 from feluda.factory import ImageFactory
-from operators.image_vec_rep_resnet import ImageVecRepResnet
+
+from .image_vec_rep_resnet import ImageVecRepResnet
 
 
 @pytest.fixture

--- a/operators/vid_vec_rep_clip/test.py
+++ b/operators/vid_vec_rep_clip/test.py
@@ -1,7 +1,8 @@
 import pytest
 
 from feluda.factory import VideoFactory
-from operators.vid_vec_rep_clip import VidVecRepClip
+
+from .vid_vec_rep_clip import VidVecRepClip
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This fixes the test imports in each individual operator - changes from absolute import to relative import. 
Absolute imports can possibly cause errors once the operator is published as a package, since the `operators` folder will not exist in that package anymore.