### PR TITLE
fix: improve semantic versioning regex and history parsing

### DIFF
--- a/scripts/semantic_release_workflow.py
+++ b/scripts/semantic_release_workflow.py
@@ -130,7 +130,7 @@ class PackageVersionManager:
             lower_message = message.lower()
 
             # Check for BREAKING CHANGE in footer/body
-            if "breaking change" in lower_message:
+            if "breaking change" in lower_message or "breaking-change" in lower_message:
                 return "major"
 
             # Parse commit type

--- a/scripts/semantic_release_workflow.py
+++ b/scripts/semantic_release_workflow.py
@@ -126,10 +126,11 @@ class PackageVersionManager:
         """
         try:
             # Normalize commit message
-            message = commit_message.lower().strip()
+            message = commit_message.strip()
+            lower_message = message.lower()
 
-            # Check for BREAKING CHANGE
-            if "breaking change" in message:
+            # Check for BREAKING CHANGE in footer/body
+            if "breaking change" in lower_message:
                 return "major"
 
             # Parse commit type
@@ -139,7 +140,8 @@ class PackageVersionManager:
             <type>(<optional scope>): <description>
             <type>[optional scope]: <description>
             """
-            match = re.match(r"^(\w+)(?:\(|\[)?[^\)\]]*(?:\)|\])?:", message)
+            # optional breaking change marker (!), and flexible spacing.
+            match = re.match(r"^(\w+)(?:\(|\[)?[^\)\]! \t:]*(?:\)|\])?(!)?\s?:", message)
             if not match:
                 # If the commit message does not match the conventional commit format
                 # and is not empty, treat it as a "chore:" and return "patch".
@@ -147,12 +149,18 @@ class PackageVersionManager:
                     return "patch"
                 return None
 
-            commit_type = match.group(1)
+            commit_type = match.group(1).lower()
+            is_breaking = bool(match.group(2))
+
+            if is_breaking:
+                return "major"
 
             # Mapping of commit types to version bump
             type_bump_map = {
                 "feat": "minor",
+                "feature": "minor",
                 "fix": "patch",
+                "bugfix": "patch",
                 "chore": "patch",
                 "docs": "patch",
                 "refactor": "patch",
@@ -239,7 +247,7 @@ class PackageVersionManager:
                 cmd = [
                     "git",
                     "log",
-                    f"{self.prev_commit}^..{self.current_commit}",
+                    f"{self.prev_commit}..{self.current_commit}",
                     "--pretty=format:%s",
                     "--",
                     path,
@@ -287,6 +295,7 @@ class PackageVersionManager:
 
             for commit in package_commits:
                 commit_bump = self._parse_conventional_commit(commit)
+                print(f"DEBUG: {package_path} commit: '{commit}' -> bump: {commit_bump}")
                 if commit_bump and bump_priority.get(
                     commit_bump, 0
                 ) > bump_priority.get(highest_bump, 0):


### PR DESCRIPTION
Pull Request concerning to Issue #680 
###  Description
I've updated the semantic versioning script to fix the issue where feat: commits were being incorrectly downgraded to patch bumps.

The main problem was a strict regex that couldn't handle breaking change markers (!) or flexible spacing before the colon. Since the script has a silent fallback to patch whenever the regex fails, these features weren't being caught correctly.

### Changes
Updated the commit parser: The regex is now more robust and supports feat!:, standard scopes (), and legacy square bracket scopes [] and even blank spaces.
Explicit Breaking Changes: The script now specifically checks for the ! marker to trigger MAJOR bumps.
Corrected Git Range: Fixed the git log boundary to properly exclude the previous release commit.
Debug Visibility: Added some print statements so we can see exactly how each commit is being parsed in the GitHub Action logs.

### Verification
I tested this locally across various commit formats (standard, scoped, breaking) to ensure they all map to the correct semantic version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader and earlier detection of breaking changes (covers hyphenated variants and optional breaking marker)
  * Improved classification of commit types for more accurate version bumps

* **Chores**
  * Expanded type coverage (including feature as minor and more patch aliases)
  * Adjusted commit range handling for package processing
  * Added debug logging for release traceability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->